### PR TITLE
feat(search): implement debounced search and clear functionality

### DIFF
--- a/lib/features/search/presentation/pages/search_page.dart
+++ b/lib/features/search/presentation/pages/search_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
@@ -68,7 +70,12 @@ class _SearchPageState extends State<SearchPage> {
             return const Center(child: CircularProgressIndicator());
           }
           if (provider.items.isEmpty) {
-            return const Center(child: Text('Search for movies or series!'));
+            return const Center(
+              child: Text(
+                'Search for movies or series!',
+                style: TextStyle(fontSize: 18, color: Colors.grey),
+              ),
+            );
           }
           return ListView.builder(
             itemCount: provider.items.length + (provider.hasMore ? 1 : 0),
@@ -166,11 +173,28 @@ class SearchBottomBar extends StatefulWidget {
 
 class _SearchBottomBarState extends State<SearchBottomBar> {
   final TextEditingController _searchController = TextEditingController();
+  Timer? _debounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _searchController.addListener(() {
+      setState(() {});
+    });
+  }
 
   @override
   void dispose() {
     _searchController.dispose();
+    _debounce?.cancel();
     super.dispose();
+  }
+
+  void _onSearchChanged(String query, SearchProvider provider) {
+    if (_debounce?.isActive ?? false) _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 500), () {
+      provider.searchMedia(query);
+    });
   }
 
   @override
@@ -187,20 +211,26 @@ class _SearchBottomBarState extends State<SearchBottomBar> {
               Expanded(
                 child: TextField(
                   controller: _searchController,
-                  decoration: const InputDecoration(
+                  decoration: InputDecoration(
                     hintText: 'Search names...',
-                    border: OutlineInputBorder(),
+                    border: const OutlineInputBorder(),
+                    prefixIcon: const Icon(Icons.search),
+                    suffixIcon: _searchController.text.isNotEmpty
+                        ? IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              _searchController.clear();
+                              Provider.of<SearchProvider>(context, listen: false).searchMedia('');
+                            },
+                          )
+                        : null,
                   ),
+                  onChanged: (value) => _onSearchChanged(value, Provider.of<SearchProvider>(context, listen: false)),
                   onSubmitted: (value) {
-                     Provider.of<SearchProvider>(context, listen: false).searchMedia(value);
+                    _debounce?.cancel();
+                    Provider.of<SearchProvider>(context, listen: false).searchMedia(value);
                   },
                 ),
-              ),
-              IconButton(
-                icon: const Icon(Icons.search),
-                onPressed: () {
-                   Provider.of<SearchProvider>(context, listen: false).searchMedia(_searchController.text);
-                },
               ),
             ],
           ),

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -25,10 +25,17 @@ class SearchProvider extends ChangeNotifier {
   bool get hasMore => _hasMore;
 
   Future<void> searchMedia(String query) async {
-    if (query.isEmpty) return;
     if (query == _searchQuery && _items.isNotEmpty) return;
 
     _searchQuery = query;
+    if (query.isEmpty) {
+      _items = [];
+      _isLoading = false;
+      _hasMore = false;
+      notifyListeners();
+      return;
+    }
+
     _isLoading = true;
     _currentPage = 1;
     _hasMore = true;
@@ -37,10 +44,13 @@ class SearchProvider extends ChangeNotifier {
 
     try {
       _items = await _mediaRepository.searchMedia(query, page: _currentPage);
-      if (_items.isEmpty)
+      if (_items.isEmpty) {
         _hasMore = false;
+      }
     } catch (e) {
       debugPrint('Failed to load movies: $e');
+      _items = [];
+      _hasMore = false;
     } finally {
       _isLoading = false;
       notifyListeners();

--- a/test/features/search/presentation/pages/search_page_test.dart
+++ b/test/features/search/presentation/pages/search_page_test.dart
@@ -37,6 +37,54 @@ void main() {
   }
 
   group('SearchPage', () {
+    testWidgets('clears text when clear button is tapped', (WidgetTester tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.byType(TextField), 'Inception');
+      await tester.pump(); // Rebuild to show clear button
+
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pump();
+
+      expect(find.text('Inception'), findsNothing);
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('triggers search automatically after typing with debounce', (WidgetTester tester) async {
+      final movies = [
+        const MediaItem(
+          id: 1,
+          title: 'Inception',
+          posterPath: null,
+          releaseDate: '2010-07-16',
+          overview: 'A mind-bending thriller',
+          mediaType: MediaType.movie
+        ),
+      ];
+      when(() => mockMediaRepository.searchMedia('Inception', page: any(named: 'page')))
+          .thenAnswer((_) async => movies);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.byType(TextField), 'Inception');
+      
+      // Should not have triggered search immediately due to debounce
+      verifyNever(() => mockMediaRepository.searchMedia('Inception', page: any(named: 'page')));
+
+      // Wait for debounce (500ms)
+      await tester.pump(const Duration(milliseconds: 600));
+
+      verify(() => mockMediaRepository.searchMedia('Inception', page: 1)).called(1);
+      
+      // Use pump() instead of pumpAndSettle() to avoid timeout from infinite CircularProgressIndicator
+      await tester.pumpo();
+      await tester.pump(const Duration(milliseconds: 100));
+      
+      expect(find.widgetWithText(ListTile, 'Inception'), findsOneWidget);
+    });
+
     testWidgets('displays results from TMDB when search is successful', (WidgetTester tester) async {
       final results = [
         const MediaItem(
@@ -62,11 +110,10 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest());
 
       await tester.enterText(find.byType(TextField), 'Inception');
-      await tester.tap(find.byIcon(Icons.search));
-      
-      // Use pump instead of pumpAndSettle because of the infinite CircularProgressIndicator
-      await tester.pump(); // Trigger search
-      await tester.pump(const Duration(milliseconds: 100)); // Wait for mock and rebuild
+      // Wait for debounce
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
 
       expect(find.widgetWithText(ListTile, 'Inception'), findsOneWidget);
       expect(find.widgetWithText(ListTile, 'Breaking Bad'), findsOneWidget);
@@ -80,8 +127,9 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest());
 
       await tester.enterText(find.byType(TextField), 'Inception');
-      await tester.tap(find.byIcon(Icons.search));
 
+      // Wait for debounce
+      await tester.pump(const Duration(milliseconds: 600));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
@@ -108,8 +156,8 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest());
 
       await tester.enterText(find.byType(TextField), 'Inception');
-      await tester.tap(find.byIcon(Icons.search));
-      
+      // Wait for debounce
+      await tester.pump(const Duration(milliseconds: 600));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
@@ -131,7 +179,7 @@ void main() {
         mediaType: MediaType.movie,
       ));
       final page2 = [
-        MediaItem(
+        const MediaItem(
           id: 100,
           title: 'Fetched Movie',
           posterPath: null,
@@ -147,7 +195,8 @@ void main() {
       await tester.pumpWidget(createWidgetUnderTest());
 
       await tester.enterText(find.byType(TextField), 'test');
-      await tester.tap(find.byIcon(Icons.search));
+      // Wait for debounce instead of tapping non-existent button
+      await tester.pump(const Duration(milliseconds: 600));
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
 
@@ -155,9 +204,10 @@ void main() {
       expect(find.text('Fetched Movie'), findsNothing);
 
       // Scroll to the bottom
-      await tester.drag(find.byType(ListView), const Offset(0, -2000));
+      await tester.drag(find.byType(ListView), const Offset(0, -5000));
       await tester.pump(); // Trigger scroll listener
       await tester.pump(const Duration(milliseconds: 100)); // Wait for fetch
+      await tester.pump(); // Rebuild with new items
 
       expect(find.text('Fetched Movie'), findsOneWidget);
       verify(() => mockMediaRepository.searchMedia('test', page: 2)).called(1);


### PR DESCRIPTION
Issues : #30 #31 

Updated the search feature to trigger searches automatically as the user types using a 500ms debounce. Enhanced the search bar UI with a prefix search icon, a conditional clear button, and moved search execution from a separate button into the text field's lifecycle.

Key changes:
- Added `_onSearchChanged` with a `Timer` for debouncing.
- Implemented a clear button in the `TextField` suffix.
- Updated `SearchProvider` to handle empty queries by clearing results.
- Added and updated widget tests to verify debouncing, text clearing, and automatic search triggering.