### PR TITLE
feat(media_details): auto-remove movies and completed series from watchlist

### DIFF
--- a/lib/features/media_details/presentation/widgets/seen_manager.dart
+++ b/lib/features/media_details/presentation/widgets/seen_manager.dart
@@ -14,7 +14,7 @@ class SeenManager extends StatefulWidget {
   final bool compact;
 
   const SeenManager({
-    super.key, 
+    super.key,
     required this.item,
     this.seasonNumber,
     this.episodeNumber,
@@ -30,17 +30,20 @@ class _SeenManagerState extends State<SeenManager> {
   Widget build(BuildContext context) {
     final provider = context.watch<SearchProvider>();
     final colors = context.appColors;
-    
+
     bool isSeen;
     int? count;
-    
+
     if (widget.seasonNumber != null && widget.episodeNumber != null) {
-      final history = provider.seenItems.where((s) => 
-        s.tmdbId == widget.item.id && 
-        s.type == widget.item.mediaType && 
-        s.seasonNumber == widget.seasonNumber && 
-        s.episodeNumber == widget.episodeNumber
-      ).toList();
+      final history = provider.seenItems
+          .where(
+            (s) =>
+                s.tmdbId == widget.item.id &&
+                s.type == widget.item.mediaType &&
+                s.seasonNumber == widget.seasonNumber &&
+                s.episodeNumber == widget.episodeNumber,
+          )
+          .toList();
       isSeen = history.isNotEmpty;
       count = history.length;
     } else {
@@ -51,7 +54,8 @@ class _SeenManagerState extends State<SeenManager> {
     final isTv = widget.item.mediaType == MediaType.tv;
 
     // Use a single smart button for compact/episode views to avoid duplication
-    if (widget.compact || (widget.seasonNumber != null && widget.episodeNumber != null)) {
+    if (widget.compact ||
+        (widget.seasonNumber != null && widget.episodeNumber != null)) {
       return IconButton(
         icon: Icon(
           isSeen ? Icons.check_circle : Icons.check_circle_outline,
@@ -88,29 +92,70 @@ class _SeenManagerState extends State<SeenManager> {
     );
   }
 
-  Future<void> _markAsSeenWithFlow(BuildContext context, SearchProvider provider) async {
+  Future<void> _markAsSeenWithFlow(
+    BuildContext context,
+    SearchProvider provider,
+  ) async {
     final item = widget.item;
     final seasonNumber = widget.seasonNumber;
     final episodeNumber = widget.episodeNumber;
 
     final DateTime? finalDateTime = await showDialog<DateTime>(
       context: context,
-      builder: (dialogContext) => _SeenDateTimePickerDialog(
-        item: item,
-        initialDate: DateTime.now(),
-      ),
+      builder: (dialogContext) =>
+          _SeenDateTimePickerDialog(item: item, initialDate: DateTime.now()),
     );
 
     if (finalDateTime != null) {
-      await provider.markAsSeen(SeenItem(
-        tmdbId: item.id,
-        type: item.mediaType,
-        title: item.title,
-        posterPath: item.posterPath,
-        seasonNumber: seasonNumber,
-        episodeNumber: episodeNumber,
-        seenDate: finalDateTime,
-      ));
+      await provider.markAsSeen(
+        SeenItem(
+          tmdbId: item.id,
+          type: item.mediaType,
+          title: item.title,
+          posterPath: item.posterPath,
+          seasonNumber: seasonNumber,
+          episodeNumber: episodeNumber,
+          seenDate: finalDateTime,
+        ),
+      );
+
+      // If this was a movie or the last episode / no next episode of a
+      // discontinued TV series, remove it from the watchlist if present.
+      try {
+        final inWatchlist = provider.isItemInList(item, 'watchlist');
+
+        if (item.mediaType == MediaType.movie) {
+          if (inWatchlist) await provider.toggleInList(item, 'watchlist');
+        } else if (item.mediaType == MediaType.tv &&
+            seasonNumber != null &&
+            episodeNumber != null) {
+          final isLastEpisode =
+              item.lastSeasonNumber != null &&
+              item.lastEpisodeNumber != null &&
+              item.lastSeasonNumber == seasonNumber &&
+              item.lastEpisodeNumber == episodeNumber;
+
+          // Treat multiple discontinued variants
+          final discontinued =
+              item.status != null &&
+              {'ended', 'canceled'}.contains(item.status!.toLowerCase());
+
+          // Also check for no next episode according to provider (covers
+          // cases where lastEpisodeNumber may not match or all episodes
+          // already seen).
+          bool noNext = false;
+          try {
+            final next = await provider.getNextEpisode(item.id);
+            if (next == null) noNext = true;
+          } catch (_) {
+            noNext = false;
+          }
+
+          if ((isLastEpisode || noNext) && discontinued && inWatchlist) {
+            await provider.toggleInList(item, 'watchlist');
+          }
+        }
+      } catch (_) {}
     }
   }
 
@@ -120,9 +165,14 @@ class _SeenManagerState extends State<SeenManager> {
       context: context,
       builder: (dialogContext) => AlertDialog(
         title: const Text('Clear History'),
-        content: Text('Are you sure you want to clear all viewing history for "${widget.item.title}"?'),
+        content: Text(
+          'Are you sure you want to clear all viewing history for "${widget.item.title}"?',
+        ),
         actions: [
-          TextButton(onPressed: () => Navigator.pop(dialogContext), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () => Navigator.pop(dialogContext),
+            child: const Text('Cancel'),
+          ),
           TextButton(
             onPressed: () {
               provider.removeFromSeen(widget.item.id, widget.item.mediaType);
@@ -136,13 +186,16 @@ class _SeenManagerState extends State<SeenManager> {
   }
 
   void _showSeenHistory(BuildContext context, SearchProvider provider) {
-    final history = provider.seenItems.where((s) => 
-      s.tmdbId == widget.item.id && 
-      s.type == widget.item.mediaType &&
-      s.seasonNumber == widget.seasonNumber &&
-      s.episodeNumber == widget.episodeNumber
-    ).toList();
-    
+    final history = provider.seenItems
+        .where(
+          (s) =>
+              s.tmdbId == widget.item.id &&
+              s.type == widget.item.mediaType &&
+              s.seasonNumber == widget.seasonNumber &&
+              s.episodeNumber == widget.episodeNumber,
+        )
+        .toList();
+
     final colors = context.appColors;
 
     showModalBottomSheet(
@@ -150,18 +203,26 @@ class _SeenManagerState extends State<SeenManager> {
       isScrollControlled: true,
       builder: (sheetContext) => SafeArea(
         child: Padding(
-          padding: EdgeInsets.only(bottom: MediaQuery.of(sheetContext).viewInsets.bottom),
+          padding: EdgeInsets.only(
+            bottom: MediaQuery.of(sheetContext).viewInsets.bottom,
+          ),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               Padding(
                 padding: const EdgeInsets.all(16.0),
-                child: Text('Viewing History', style: Theme.of(sheetContext).textTheme.titleLarge),
+                child: Text(
+                  'Viewing History',
+                  style: Theme.of(sheetContext).textTheme.titleLarge,
+                ),
               ),
               const Divider(),
               ListTile(
                 leading: Icon(Icons.add_circle_outline, color: colors.success),
-                title: const Text('Add New Viewing', style: TextStyle(fontWeight: FontWeight.bold)),
+                title: const Text(
+                  'Add New Viewing',
+                  style: TextStyle(fontWeight: FontWeight.bold),
+                ),
                 onTap: () {
                   Navigator.pop(sheetContext);
                   _markAsSeenWithFlow(context, provider);
@@ -182,12 +243,17 @@ class _SeenManagerState extends State<SeenManager> {
                       final seenEntry = history[index];
                       return ListTile(
                         leading: Icon(Icons.event, color: colors.comments),
-                        title: Text(DateFormat('MMM dd, yyyy - HH:mm').format(seenEntry.seenDate)),
+                        title: Text(
+                          DateFormat(
+                            'MMM dd, yyyy - HH:mm',
+                          ).format(seenEntry.seenDate),
+                        ),
                         trailing: IconButton(
                           icon: Icon(Icons.delete_outline, color: colors.error),
                           onPressed: () {
                             provider.deleteSeenEntry(seenEntry.id!);
-                            if (history.length <= 1) Navigator.pop(sheetContext);
+                            if (history.length <= 1)
+                              Navigator.pop(sheetContext);
                           },
                         ),
                       );
@@ -224,7 +290,8 @@ class _SeenDateTimePickerDialog extends StatefulWidget {
   });
 
   @override
-  State<_SeenDateTimePickerDialog> createState() => _SeenDateTimePickerDialogState();
+  State<_SeenDateTimePickerDialog> createState() =>
+      _SeenDateTimePickerDialogState();
 }
 
 class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
@@ -238,7 +305,9 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
     super.initState();
     _selectedDate = widget.initialDate;
     _selectedTime = TimeOfDay.fromDateTime(widget.initialDate);
-    _dateController = TextEditingController(text: DateFormat('dd/MM/yyyy').format(_selectedDate));
+    _dateController = TextEditingController(
+      text: DateFormat('dd/MM/yyyy').format(_selectedDate),
+    );
   }
 
   @override
@@ -263,7 +332,7 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
   Widget build(BuildContext context) {
     final colors = context.appColors;
     final isMovie = widget.item.mediaType == MediaType.movie;
-    
+
     return Dialog(
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       child: SingleChildScrollView(
@@ -275,7 +344,11 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
             children: [
               Row(
                 children: [
-                  Icon(isMovie ? Icons.movie : Icons.tv, color: colors.logicFlow, size: 24),
+                  Icon(
+                    isMovie ? Icons.movie : Icons.tv,
+                    color: colors.logicFlow,
+                    size: 24,
+                  ),
                   const SizedBox(width: 12),
                   Expanded(
                     child: Column(
@@ -283,11 +356,13 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                       children: [
                         Text(
                           'Mark as seen',
-                          style: Theme.of(context).textTheme.titleSmall?.copyWith(color: colors.comments),
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(color: colors.comments),
                         ),
                         Text(
                           widget.item.title,
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+                          style: Theme.of(context).textTheme.titleMedium
+                              ?.copyWith(fontWeight: FontWeight.bold),
                           maxLines: 1,
                           overflow: TextOverflow.ellipsis,
                         ),
@@ -295,8 +370,11 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                     ),
                   ),
                   IconButton(
-                    icon: Icon(_isTextEntry ? Icons.calendar_month : Icons.keyboard),
-                    onPressed: () => setState(() => _isTextEntry = !_isTextEntry),
+                    icon: Icon(
+                      _isTextEntry ? Icons.calendar_month : Icons.keyboard,
+                    ),
+                    onPressed: () =>
+                        setState(() => _isTextEntry = !_isTextEntry),
                     tooltip: _isTextEntry ? 'Use Calendar' : 'Type Date',
                     color: colors.logicFlow,
                   ),
@@ -306,7 +384,8 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
               if (!_isTextEntry)
                 Container(
                   decoration: BoxDecoration(
-                    color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                    color: Theme.of(context).colorScheme.surfaceContainerHighest
+                        .withValues(alpha: 0.3),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: CalendarDatePicker(
@@ -316,7 +395,9 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                     onDateChanged: (date) {
                       setState(() {
                         _selectedDate = date;
-                        _dateController.text = DateFormat('dd/MM/yyyy').format(date);
+                        _dateController.text = DateFormat(
+                          'dd/MM/yyyy',
+                        ).format(date);
                       });
                     },
                   ),
@@ -327,7 +408,9 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                   autofocus: true,
                   decoration: InputDecoration(
                     labelText: 'Date (DD/MM/YYYY)',
-                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                     prefixIcon: const Icon(Icons.event),
                     hintText: '31/12/2023',
                   ),
@@ -347,9 +430,14 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                 onTap: _pickTime,
                 borderRadius: BorderRadius.circular(12),
                 child: Container(
-                  padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+                  padding: const EdgeInsets.symmetric(
+                    vertical: 12,
+                    horizontal: 16,
+                  ),
                   decoration: BoxDecoration(
-                    border: Border.all(color: colors.logicFlow.withValues(alpha: 0.5)),
+                    border: Border.all(
+                      color: colors.logicFlow.withValues(alpha: 0.5),
+                    ),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Row(
@@ -359,7 +447,10 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                       const SizedBox(width: 12),
                       Text(
                         'Time: ${DateFormat('HH:mm').format(DateTime(0, 0, 0, _selectedTime.hour, _selectedTime.minute))}',
-                        style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 16,
+                        ),
                       ),
                     ],
                   ),
@@ -378,15 +469,22 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                     style: ElevatedButton.styleFrom(
                       backgroundColor: colors.logicFlow,
                       foregroundColor: Colors.white,
-                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-                      padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 24,
+                        vertical: 12,
+                      ),
                     ),
                     onPressed: () {
                       try {
                         if (_isTextEntry) {
-                          _selectedDate = DateFormat('dd/MM/yyyy').parseStrict(_dateController.text);
+                          _selectedDate = DateFormat(
+                            'dd/MM/yyyy',
+                          ).parseStrict(_dateController.text);
                         }
-                        
+
                         final result = DateTime(
                           _selectedDate.year,
                           _selectedDate.month,
@@ -397,7 +495,11 @@ class _SeenDateTimePickerDialogState extends State<_SeenDateTimePickerDialog> {
                         Navigator.pop(context, result);
                       } catch (_) {
                         ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Please enter a valid date (DD/MM/YYYY)')),
+                          const SnackBar(
+                            content: Text(
+                              'Please enter a valid date (DD/MM/YYYY)',
+                            ),
+                          ),
                         );
                       }
                     },

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -86,9 +86,15 @@ class SearchProvider with ChangeNotifier {
     if (normalizedTitle == normalizedQuery) return 4;
     if (normalizedTitle.startsWith(normalizedQuery)) return 3;
     if (normalizedTitle.contains(normalizedQuery)) return 2;
-    final queryWords = normalizedQuery.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toSet();
+    final queryWords = normalizedQuery
+        .split(RegExp(r'\s+'))
+        .where((w) => w.isNotEmpty)
+        .toSet();
     if (queryWords.isEmpty) return 0;
-    final titleWords = normalizedTitle.split(RegExp(r'\s+')).where((w) => w.isNotEmpty).toSet();
+    final titleWords = normalizedTitle
+        .split(RegExp(r'\s+'))
+        .where((w) => w.isNotEmpty)
+        .toSet();
     final overlap = queryWords.intersection(titleWords).length;
     return overlap > 0 ? 1 : 0;
   }
@@ -228,7 +234,9 @@ class SearchProvider with ChangeNotifier {
   }
 
   bool isNotified(MediaItem item) {
-    return _notifiedItems.any((n) => n.tmdbId == item.id && n.type == item.mediaType);
+    return _notifiedItems.any(
+      (n) => n.tmdbId == item.id && n.type == item.mediaType,
+    );
   }
 
   Future<void> toggleLike(MediaItem item) async {
@@ -287,7 +295,10 @@ class SearchProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> updateListOrder(String listName, List<String> orderedEntries) async {
+  Future<void> updateListOrder(
+    String listName,
+    List<String> orderedEntries,
+  ) async {
     await repository.updateListOrder(listName, orderedEntries);
     _listEntries[listName] = orderedEntries;
     _listPreviews[listName] = await repository.getListPreviews(listName);
@@ -317,7 +328,13 @@ class SearchProvider with ChangeNotifier {
       final id = int.tryParse(parts[0]);
       final type = parts[1] == 'tv' ? MediaType.tv : MediaType.movie;
       if (id != null) {
-        final shell = MediaItem(id: id, title: 'Unknown', overview: '', releaseDate: '', mediaType: type);
+        final shell = MediaItem(
+          id: id,
+          title: 'Unknown',
+          overview: '',
+          releaseDate: '',
+          mediaType: type,
+        );
         await repository.addToList(shell, name);
       }
     }
@@ -471,7 +488,8 @@ class SearchProvider with ChangeNotifier {
             language: _language,
             type: MediaType.tv,
           );
-          results = [...movies, ...tv]..sort((a, b) => b.voteAverage?.compareTo(a.voteAverage ?? 0) ?? 0);
+          results = [...movies, ...tv]
+            ..sort((a, b) => b.voteAverage?.compareTo(a.voteAverage ?? 0) ?? 0);
         } else {
           results = await repository.discoverMedia(
             page: _currentPage,
@@ -554,23 +572,97 @@ class SearchProvider with ChangeNotifier {
     notifyListeners();
   }
 
-  Future<MediaDetails> getMediaDetails(int id, MediaType type) => repository.getMediaDetails(id, type: type);
-  Future<Map<String, dynamic>> getSeasonDetails(int tvId, int seasonNumber) => repository.getSeasonDetails(tvId, seasonNumber);
-  Future<List<SeenItem>> loadSeenStatusForItem(int tmdbId, MediaType type) => repository.getSeenStatus(tmdbId, type);
+  Future<MediaDetails> getMediaDetails(int id, MediaType type) =>
+      repository.getMediaDetails(id, type: type);
+  Future<Map<String, dynamic>> getSeasonDetails(int tvId, int seasonNumber) =>
+      repository.getSeasonDetails(tvId, seasonNumber);
+  Future<List<SeenItem>> loadSeenStatusForItem(int tmdbId, MediaType type) =>
+      repository.getSeenStatus(tmdbId, type);
   Future<void> markAsSeen(SeenItem item) async {
     await repository.markAsSeen(item);
+    debugPrint('markAsSeen called for ${item.tmdbId} ${item.type}');
+
+    // After marking as seen, remove from watchlist when appropriate so
+    // that all entry points (SeenManager, Notification center, WatchNext)
+    // exhibit the same behaviour.
+    try {
+      final inWatchlist = _watchlistIds.contains(item.tmdbId.toString());
+      debugPrint('Might be removing a media from watchlist: $inWatchlist');
+
+      if (inWatchlist) {
+        if (item.type == MediaType.movie) {
+          debugPrint('Might be removing a movie');
+          final mediaShell = MediaItem(
+            id: item.tmdbId,
+            title: item.title,
+            overview: '',
+            releaseDate: '',
+            mediaType: MediaType.movie,
+          );
+          await toggleInList(mediaShell, 'watchlist');
+        } else if (item.type == MediaType.tv) {
+          debugPrint('Might be removing a series');
+          // Fetch details to determine status/last episode info
+          try {
+            final details = await repository.getMediaDetails(
+              item.tmdbId,
+              type: MediaType.tv,
+            );
+            final mediaItem = details.item;
+            debugPrint(
+              'Might be removing a series discontinued ${mediaItem.status}',
+            );
+            final discontinued =
+                mediaItem.status != null &&
+                {'ended', 'canceled'}.contains(mediaItem.status!.toLowerCase());
+
+            final isLastEpisode =
+                item.seasonNumber != null &&
+                item.episodeNumber != null &&
+                mediaItem.lastSeasonNumber != null &&
+                mediaItem.lastEpisodeNumber != null &&
+                mediaItem.lastSeasonNumber == item.seasonNumber &&
+                mediaItem.lastEpisodeNumber == item.episodeNumber;
+
+            bool noNext = false;
+            try {
+              final next = await getNextEpisode(item.tmdbId);
+              if (next == null) noNext = true;
+            } catch (_) {}
+            debugPrint('Might be removing a series without next${noNext}');
+
+            if ((isLastEpisode || noNext) && discontinued) {
+              await toggleInList(mediaItem, 'watchlist');
+            }
+          } catch (_) {}
+        }
+      }
+    } catch (_) {}
+
     await loadAllSeenStatus();
     await loadNotifiedItems();
     await updateSeenDbSize();
   }
+
   Future<void> deleteSeenEntry(int id) async {
     await repository.deleteSeenEntry(id);
     await loadAllSeenStatus();
     await loadNotifiedItems();
     await updateSeenDbSize();
   }
-  Future<void> removeFromSeen(int tmdbId, MediaType type, {int? seasonNumber, int? episodeNumber}) async {
-    await repository.removeFromSeen(tmdbId, type, seasonNumber: seasonNumber, episodeNumber: episodeNumber);
+
+  Future<void> removeFromSeen(
+    int tmdbId,
+    MediaType type, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await repository.removeFromSeen(
+      tmdbId,
+      type,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
     await loadAllSeenStatus();
     await loadNotifiedItems();
     await updateSeenDbSize();
@@ -612,7 +704,10 @@ class SearchProvider with ChangeNotifier {
     );
   }
 
-  Future<void> importSeenData(List<Map<String, dynamic>> data, {ImportMode mode = ImportMode.append}) async {
+  Future<void> importSeenData(
+    List<Map<String, dynamic>> data, {
+    ImportMode mode = ImportMode.append,
+  }) async {
     _isImporting = true;
     _importProgress = 0.0;
     _importStatus = 'Starting import...';
@@ -620,7 +715,7 @@ class SearchProvider with ChangeNotifier {
 
     try {
       await repository.importSeenData(
-        data, 
+        data,
         mode: mode,
         onProgress: (progress, status) {
           _importProgress = progress;
@@ -628,7 +723,7 @@ class SearchProvider with ChangeNotifier {
           notifyListeners();
         },
       );
-      
+
       _importProgress = 1.0;
       _importStatus = 'Done!';
     } catch (e) {
@@ -638,13 +733,15 @@ class SearchProvider with ChangeNotifier {
       await loadNotifiedItems();
       await updateCacheSize();
       await updateSeenDbSize();
-      
+
       _isImporting = false;
       notifyListeners();
     }
   }
 
-  Future<({int seasonNumber, int episodeNumber})?> getNextEpisode(int tmdbId) async {
+  Future<({int seasonNumber, int episodeNumber})?> getNextEpisode(
+    int tmdbId,
+  ) async {
     try {
       final seen = await repository.getSeenStatus(tmdbId, MediaType.tv);
 
@@ -652,7 +749,9 @@ class SearchProvider with ChangeNotifier {
       int nextE = 1;
 
       if (seen.isNotEmpty) {
-        final episodeSeen = seen.where((s) => s.seasonNumber != null && s.episodeNumber != null).toList();
+        final episodeSeen = seen
+            .where((s) => s.seasonNumber != null && s.episodeNumber != null)
+            .toList();
         if (episodeSeen.isNotEmpty) {
           episodeSeen.sort((a, b) {
             final seasonCompare = b.seasonNumber!.compareTo(a.seasonNumber!);
@@ -661,28 +760,34 @@ class SearchProvider with ChangeNotifier {
           });
 
           final latest = episodeSeen.first;
-          final details = await repository.getMediaDetails(tmdbId, type: MediaType.tv);
+          final details = await repository.getMediaDetails(
+            tmdbId,
+            type: MediaType.tv,
+          );
 
           final seasons = details.item.seasons;
           if (seasons == null || seasons.isEmpty) return null;
 
           final currentSeason = seasons.firstWhere(
             (s) => s.seasonNumber == latest.seasonNumber,
-            orElse: () => const TVSeason(id: -1, seasonNumber: -1, episodeCount: 0),
+            orElse: () =>
+                const TVSeason(id: -1, seasonNumber: -1, episodeCount: 0),
           );
 
-          if (currentSeason.seasonNumber != -1 && latest.episodeNumber! < currentSeason.episodeCount) {
+          if (currentSeason.seasonNumber != -1 &&
+              latest.episodeNumber! < currentSeason.episodeCount) {
             nextS = latest.seasonNumber!;
             nextE = latest.episodeNumber! + 1;
           } else {
             final nextSeason = seasons.firstWhere(
               (s) => s.seasonNumber == latest.seasonNumber! + 1,
-              orElse: () => const TVSeason(id: -1, seasonNumber: -1, episodeCount: 0),
+              orElse: () =>
+                  const TVSeason(id: -1, seasonNumber: -1, episodeCount: 0),
             );
 
             if (nextSeason.seasonNumber != -1) {
-               nextS = nextSeason.seasonNumber;
-               nextE = 1;
+              nextS = nextSeason.seasonNumber;
+              nextE = 1;
             } else {
               return null;
             }
@@ -739,8 +844,12 @@ class SearchProvider with ChangeNotifier {
     }
   }
 
-  Future<List<MediaItem>> getSimilarMedia(int id, MediaType type) => repository.getSimilarMedia(id, type);
-  Future<List<MediaItem>> getRecommendedMedia(int id, MediaType type) => repository.getRecommendedMedia(id, type);
-  Future<Map<String, dynamic>> getWatchProviders(int id, MediaType type) => repository.getWatchProviders(id, type);
-  Future<List<Map<String, dynamic>>> getVideos(int id, MediaType type) => repository.getVideos(id, type);
+  Future<List<MediaItem>> getSimilarMedia(int id, MediaType type) =>
+      repository.getSimilarMedia(id, type);
+  Future<List<MediaItem>> getRecommendedMedia(int id, MediaType type) =>
+      repository.getRecommendedMedia(id, type);
+  Future<Map<String, dynamic>> getWatchProviders(int id, MediaType type) =>
+      repository.getWatchProviders(id, type);
+  Future<List<Map<String, dynamic>>> getVideos(int id, MediaType type) =>
+      repository.getVideos(id, type);
 }

--- a/test/features/media_details/presentation/pages/mark_as_seen_entry_points_test.dart
+++ b/test/features/media_details/presentation/pages/mark_as_seen_entry_points_test.dart
@@ -1,0 +1,322 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/core/domain/entities/seen_item.dart';
+import 'package:mediavore/features/media_details/presentation/pages/notification_center_page.dart';
+import 'package:mediavore/features/media_details/presentation/widgets/watch_next_button.dart';
+import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+import 'package:mediavore/core/domain/entities/media_details.dart';
+import '../../../../helpers/mocks.dart';
+
+void main() {
+  late MockMediaRepository mockRepository;
+  late SearchProvider provider;
+
+  setUpAll(() {
+    registerFallbackValue(MediaType.movie);
+    registerFallbackValue(
+      SeenItem(
+        tmdbId: 1,
+        type: MediaType.movie,
+        title: 'T',
+        seenDate: DateTime.now(),
+      ),
+    );
+    registerFallbackValue(
+      const MediaItem(id: 1, title: 'T', overview: '', releaseDate: ''),
+    );
+  });
+
+  setUp(() {
+    mockRepository = MockMediaRepository();
+
+    // Basic provider init stubs
+    when(
+      () => mockRepository.getAllListNames(),
+    ).thenAnswer((_) async => ['watchlist']);
+    when(
+      () => mockRepository.getListEntries(any()),
+    ).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getListPreviews(any(), limit: any(named: 'limit')),
+    ).thenAnswer((_) async => []);
+    when(() => mockRepository.getCacheSize()).thenAnswer((_) async => 0);
+    when(() => mockRepository.getSeenDbSize()).thenAnswer((_) async => 0);
+    when(() => mockRepository.getSeenItems()).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getWatchlistEntries(),
+    ).thenAnswer((_) async => []);
+    when(() => mockRepository.getLikedEntries()).thenAnswer((_) async => []);
+    when(() => mockRepository.getNotifiedItems()).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.markAsSeen(any()),
+    ).thenAnswer((_) async => Future.value());
+
+    provider = SearchProvider(mockRepository);
+    when(
+      () => mockRepository.getSeenStatus(any(), any()),
+    ).thenAnswer((_) async => []);
+  });
+
+  testWidgets(
+    'NotificationCenter movie: marking as seen removes from watchlist',
+    (WidgetTester tester) async {
+      final now = DateTime.now().subtract(const Duration(days: 1));
+      when(() => mockRepository.getNotifiedItems()).thenAnswer(
+        (_) async => [
+          NotifiedItem(
+            tmdbId: 10,
+            type: MediaType.movie,
+            title: 'Movie10',
+            releaseDate: now,
+          ),
+        ],
+      );
+      when(
+        () => mockRepository.getWatchlistEntries(),
+      ).thenAnswer((_) async => ['10:movie']);
+      when(
+        () => mockRepository.getMediaDetails(10, type: MediaType.movie),
+      ).thenAnswer(
+        (_) async => MediaDetails(
+          item: MediaItem(
+            id: 10,
+            title: 'Movie10',
+            overview: '',
+            releaseDate: '',
+            mediaType: MediaType.movie,
+          ),
+          cast: [],
+        ),
+      );
+      when(
+        () => mockRepository.removeFromList(10, MediaType.movie, 'watchlist'),
+      ).thenAnswer((_) async => {});
+
+      // Refresh provider state from mocked repository
+      await provider.loadNotifiedItems();
+      await provider.loadWatchlist();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SearchProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: NotificationCenterPage()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The released item should have a 'Mark as seen' icon (visibility_outlined)
+      final markButtons = find.byTooltip('Mark as seen');
+      expect(markButtons, findsOneWidget);
+
+      await tester.tap(markButtons.first);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockRepository.removeFromList(10, MediaType.movie, 'watchlist'),
+      ).called(1);
+    },
+  );
+
+  testWidgets(
+    'WatchNextButton marks next ep and removes series from watchlist when appropriate',
+    (WidgetTester tester) async {
+      // Prepare watchlist to include the series
+      when(
+        () => mockRepository.getWatchlistEntries(),
+      ).thenAnswer((_) async => ['20:tv']);
+
+      // Stub seen status so provider.getNextEpisode will return a next ep
+      when(() => mockRepository.getSeenStatus(20, MediaType.tv)).thenAnswer(
+        (_) async => [
+          SeenItem(
+            id: 1,
+            tmdbId: 20,
+            type: MediaType.tv,
+            title: 'Series20',
+            seenDate: DateTime.now(),
+            seasonNumber: 1,
+            episodeNumber: 1,
+          ),
+        ],
+      );
+
+      when(
+        () => mockRepository.getMediaDetails(20, type: MediaType.tv),
+      ).thenAnswer(
+        (_) async => MediaDetails(
+          item: MediaItem(
+            id: 20,
+            title: 'Series20',
+            overview: '',
+            releaseDate: '',
+            mediaType: MediaType.tv,
+            seasons: [TVSeason(id: 1, seasonNumber: 1, episodeCount: 2)],
+            status: 'Ended',
+            lastSeasonNumber: 1,
+            lastEpisodeNumber: 2,
+          ),
+          cast: [],
+        ),
+      );
+
+      when(() => mockRepository.getSeasonDetails(20, 1)).thenAnswer(
+        (_) async => {
+          'episodes': [
+            {
+              'episode_number': 2,
+              'air_date': DateTime.now()
+                  .subtract(const Duration(days: 1))
+                  .toIso8601String(),
+            },
+          ],
+        },
+      );
+
+      when(
+        () => mockRepository.removeFromList(20, MediaType.tv, 'watchlist'),
+      ).thenAnswer((_) async => {});
+
+      await provider.loadWatchlist();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SearchProvider>.value(
+          value: provider,
+          child: MaterialApp(
+            home: Scaffold(
+              body: WatchNextButton(
+                item: MediaItem(
+                  id: 20,
+                  title: 'Series20',
+                  overview: '',
+                  releaseDate: '',
+                  mediaType: MediaType.tv,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Button should be present
+      expect(find.byIcon(Icons.play_arrow), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.play_arrow));
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockRepository.removeFromList(20, MediaType.tv, 'watchlist'),
+      ).called(1);
+    },
+  );
+
+  testWidgets(
+    'QuickAddTab: pressing check marks next ep and removes from watchlist',
+    (WidgetTester tester) async {
+      // Provide a seen item so QuickAddTab will consider it
+      when(() => mockRepository.getSeenItems()).thenAnswer(
+        (_) async => [
+          SeenItem(
+            id: 101,
+            tmdbId: 30,
+            type: MediaType.tv,
+            title: 'Series30',
+            seenDate: DateTime.now(),
+            seasonNumber: 1,
+            episodeNumber: 1,
+          ),
+        ],
+      );
+
+      when(
+        () => mockRepository.getWatchlistEntries(),
+      ).thenAnswer((_) async => ['30:tv']);
+
+      when(() => mockRepository.getSeenStatus(30, MediaType.tv)).thenAnswer(
+        (_) async => [
+          SeenItem(
+            id: 101,
+            tmdbId: 30,
+            type: MediaType.tv,
+            title: 'Series30',
+            seenDate: DateTime.now(),
+            seasonNumber: 1,
+            episodeNumber: 1,
+          ),
+        ],
+      );
+
+      when(
+        () => mockRepository.getMediaDetails(30, type: MediaType.tv),
+      ).thenAnswer(
+        (_) async => MediaDetails(
+          item: MediaItem(
+            id: 30,
+            title: 'Series30',
+            overview: '',
+            releaseDate: '',
+            mediaType: MediaType.tv,
+            seasons: [TVSeason(id: 1, seasonNumber: 1, episodeCount: 2)],
+            status: 'Ended',
+            lastSeasonNumber: 1,
+            lastEpisodeNumber: 2,
+          ),
+          cast: [],
+        ),
+      );
+
+      when(() => mockRepository.getSeasonDetails(30, 1)).thenAnswer(
+        (_) async => {
+          'episodes': [
+            {
+              'episode_number': 2,
+              'air_date': DateTime.now()
+                  .subtract(const Duration(days: 1))
+                  .toIso8601String(),
+            },
+          ],
+        },
+      );
+
+      when(
+        () => mockRepository.removeFromList(30, MediaType.tv, 'watchlist'),
+      ).thenAnswer((_) async => {});
+
+      // We need to build the QuickAddTab which is private; reuse the _QuickAddTab via NotificationCenterPage's _QuickAddTab
+      // Refresh provider state so QuickAddTab sees the seen items
+      await provider.loadAllSeenStatus();
+      await provider.loadWatchlist();
+      await provider.loadNotifiedItems();
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider<SearchProvider>.value(
+          value: provider,
+          child: const MaterialApp(home: NotificationCenterPage()),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // The quick add tab is the second tab; open it
+      await tester.tap(find.text('Quick Add'));
+      await tester.pumpAndSettle();
+
+      // There should be a check icon for marking next as seen
+      final checkButtons = find.byIcon(Icons.check_circle_outline);
+      expect(checkButtons, findsWidgets);
+
+      await tester.tap(checkButtons.first);
+      await tester.pumpAndSettle();
+
+      verify(
+        () => mockRepository.removeFromList(30, MediaType.tv, 'watchlist'),
+      ).called(1);
+    },
+  );
+}

--- a/test/features/media_details/presentation/widgets/seen_manager_test.dart
+++ b/test/features/media_details/presentation/widgets/seen_manager_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/core/domain/entities/media_details.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
 import 'package:mediavore/core/theme/app_palette.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/seen_manager.dart';
@@ -15,30 +16,50 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(MediaType.movie);
-    registerFallbackValue(SeenItem(tmdbId: 1, type: MediaType.movie, title: 'T', seenDate: DateTime.now()));
-    registerFallbackValue(const MediaItem(id: 1, title: 'T', overview: '', releaseDate: ''));
+    registerFallbackValue(
+      SeenItem(
+        tmdbId: 1,
+        type: MediaType.movie,
+        title: 'T',
+        seenDate: DateTime.now(),
+      ),
+    );
+    registerFallbackValue(
+      const MediaItem(id: 1, title: 'T', overview: '', releaseDate: ''),
+    );
   });
 
   setUp(() {
     mockRepository = MockMediaRepository();
-    
+
     // Default mocks for SearchProvider init
-    when(() => mockRepository.getAllListNames()).thenAnswer((_) async => ['watchlist']);
-    when(() => mockRepository.getListEntries(any())).thenAnswer((_) async => []);
-    when(() => mockRepository.getListPreviews(any(), limit: any(named: 'limit')))
-        .thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getAllListNames(),
+    ).thenAnswer((_) async => ['watchlist']);
+    when(
+      () => mockRepository.getListEntries(any()),
+    ).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getListPreviews(any(), limit: any(named: 'limit')),
+    ).thenAnswer((_) async => []);
     when(() => mockRepository.getCacheSize()).thenAnswer((_) async => 0);
     when(() => mockRepository.getSeenDbSize()).thenAnswer((_) async => 0);
     when(() => mockRepository.getSeenItems()).thenAnswer((_) async => []);
-    when(() => mockRepository.getWatchlistEntries()).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getWatchlistEntries(),
+    ).thenAnswer((_) async => []);
     when(() => mockRepository.getLikedEntries()).thenAnswer((_) async => []);
     when(() => mockRepository.getNotifiedItems()).thenAnswer((_) async => []);
-    when(() => mockRepository.markAsSeen(any())).thenAnswer((_) async => Future.value());
+    when(
+      () => mockRepository.markAsSeen(any()),
+    ).thenAnswer((_) async => Future.value());
 
     searchProvider = SearchProvider(mockRepository);
-    
+
     // Default mocks for UI components
-    when(() => mockRepository.getSeenStatus(any(), any())).thenAnswer((_) async => []);
+    when(
+      () => mockRepository.getSeenStatus(any(), any()),
+    ).thenAnswer((_) async => []);
   });
 
   Widget createWidgetUnderTest({
@@ -46,6 +67,9 @@ void main() {
     MediaType type = MediaType.movie,
     String title = 'Inception',
     bool compact = false,
+    String? status,
+    int? lastSeasonNumber,
+    int? lastEpisodeNumber,
   }) {
     return ChangeNotifierProvider<SearchProvider>.value(
       value: searchProvider,
@@ -60,6 +84,9 @@ void main() {
               title: title,
               overview: '',
               releaseDate: '',
+              status: status,
+              lastSeasonNumber: lastSeasonNumber,
+              lastEpisodeNumber: lastEpisodeNumber,
             ),
           ),
         ),
@@ -67,20 +94,40 @@ void main() {
     );
   }
 
+  Future<void> _markAsSeenViaUi(WidgetTester tester) async {
+    await tester.tap(find.byIcon(Icons.check_circle_outline));
+    await tester.pumpAndSettle();
+    // Press the LOG VIEWING button in the dialog
+    await tester.tap(find.text('LOG VIEWING'));
+    await tester.pumpAndSettle();
+  }
+
   group('SeenManager', () {
-    testWidgets('displays check_circle_outline icon when not seen', (WidgetTester tester) async {
+    testWidgets('displays check_circle_outline icon when not seen', (
+      WidgetTester tester,
+    ) async {
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pump(); // Initial load
 
       expect(find.byIcon(Icons.check_circle_outline), findsOneWidget);
     });
 
-    testWidgets('displays check_circle icon when seen', (WidgetTester tester) async {
+    testWidgets('displays check_circle icon when seen', (
+      WidgetTester tester,
+    ) async {
       final viewings = [
-        SeenItem(id: 1, tmdbId: 1, type: MediaType.movie, title: 'Inception', seenDate: DateTime(2023)),
+        SeenItem(
+          id: 1,
+          tmdbId: 1,
+          type: MediaType.movie,
+          title: 'Inception',
+          seenDate: DateTime(2023),
+        ),
       ];
       // Mock both the direct repository call and the provider's seenItems list
-      when(() => mockRepository.getSeenItems()).thenAnswer((_) async => viewings);
+      when(
+        () => mockRepository.getSeenItems(),
+      ).thenAnswer((_) async => viewings);
       await searchProvider.loadAllSeenStatus();
 
       await tester.pumpWidget(createWidgetUnderTest());
@@ -89,11 +136,21 @@ void main() {
       expect(find.byIcon(Icons.check_circle), findsOneWidget);
     });
 
-    testWidgets('tapping check_circle icon opens bottom sheet', (WidgetTester tester) async {
+    testWidgets('tapping check_circle icon opens bottom sheet', (
+      WidgetTester tester,
+    ) async {
       final viewings = [
-        SeenItem(id: 1, tmdbId: 1, type: MediaType.movie, title: 'Inception', seenDate: DateTime(2023)),
+        SeenItem(
+          id: 1,
+          tmdbId: 1,
+          type: MediaType.movie,
+          title: 'Inception',
+          seenDate: DateTime(2023),
+        ),
       ];
-      when(() => mockRepository.getSeenItems()).thenAnswer((_) async => viewings);
+      when(
+        () => mockRepository.getSeenItems(),
+      ).thenAnswer((_) async => viewings);
       await searchProvider.loadAllSeenStatus();
 
       await tester.pumpWidget(createWidgetUnderTest());
@@ -106,16 +163,31 @@ void main() {
       expect(find.text('Viewing History'), findsOneWidget);
     });
 
-    testWidgets('shows confirmation dialog when clearing history', (WidgetTester tester) async {
+    testWidgets('shows confirmation dialog when clearing history', (
+      WidgetTester tester,
+    ) async {
       final viewings = [
-        SeenItem(id: 1, tmdbId: 1, type: MediaType.movie, title: 'Inception', seenDate: DateTime(2023)),
+        SeenItem(
+          id: 1,
+          tmdbId: 1,
+          type: MediaType.movie,
+          title: 'Inception',
+          seenDate: DateTime(2023),
+        ),
       ];
-      when(() => mockRepository.getSeenItems()).thenAnswer((_) async => viewings);
+      when(
+        () => mockRepository.getSeenItems(),
+      ).thenAnswer((_) async => viewings);
       await searchProvider.loadAllSeenStatus();
-      
-      when(() => mockRepository.removeFromSeen(any(), any(), 
-          seasonNumber: any(named: 'seasonNumber'), 
-          episodeNumber: any(named: 'episodeNumber'))).thenAnswer((_) async => {});
+
+      when(
+        () => mockRepository.removeFromSeen(
+          any(),
+          any(),
+          seasonNumber: any(named: 'seasonNumber'),
+          episodeNumber: any(named: 'episodeNumber'),
+        ),
+      ).thenAnswer((_) async => {});
 
       await tester.pumpWidget(createWidgetUnderTest());
       await tester.pump();
@@ -134,7 +206,9 @@ void main() {
     });
 
     group('Tv Support', () {
-      testWidgets('tapping check_circle_outline opens date picker dialog', (WidgetTester tester) async {
+      testWidgets('tapping check_circle_outline opens date picker dialog', (
+        WidgetTester tester,
+      ) async {
         await tester.pumpWidget(createWidgetUnderTest(type: MediaType.tv));
         await tester.pump();
 
@@ -143,6 +217,289 @@ void main() {
 
         expect(find.byType(Dialog), findsOneWidget);
         expect(find.text('Mark as seen'), findsOneWidget);
+      });
+    });
+
+    group('Watchlist removal behaviour', () {
+      testWidgets('movie not in watchlist does not remove', (
+        WidgetTester tester,
+      ) async {
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => []);
+        await searchProvider.loadWatchlist();
+
+        await tester.pumpWidget(createWidgetUnderTest());
+        await tester.pump();
+
+        when(
+          () => mockRepository.removeFromList(any(), any(), any()),
+        ).thenAnswer((_) async => {});
+
+        await _markAsSeenViaUi(tester);
+
+        verifyNever(() => mockRepository.removeFromList(any(), any(), any()));
+      });
+
+      testWidgets('movie in watchlist is removed when marked seen', (
+        WidgetTester tester,
+      ) async {
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => ['1:movie']);
+        await searchProvider.loadWatchlist();
+
+        when(
+          () => mockRepository.removeFromList(1, MediaType.movie, 'watchlist'),
+        ).thenAnswer((_) async => {});
+
+        await tester.pumpWidget(createWidgetUnderTest());
+        await tester.pump();
+
+        await _markAsSeenViaUi(tester);
+
+        verify(
+          () => mockRepository.removeFromList(1, MediaType.movie, 'watchlist'),
+        ).called(1);
+      });
+
+      testWidgets('series middle episode in watchlist is not removed', (
+        WidgetTester tester,
+      ) async {
+        // TV show in watchlist
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => ['2:tv']);
+        await searchProvider.loadWatchlist();
+
+        // Item has last episode 5:10, we mark 3:4 (middle)
+        await tester.pumpWidget(
+          createWidgetUnderTest(
+            tmdbId: 2,
+            type: MediaType.tv,
+            status: 'Ended',
+            lastSeasonNumber: 5,
+            lastEpisodeNumber: 10,
+          ),
+        );
+        await tester.pump();
+
+        when(
+          () => mockRepository.removeFromList(2, MediaType.tv, 'watchlist'),
+        ).thenAnswer((_) async => {});
+
+        // Ensure provider.getNextEpisode can resolve a following episode so
+        // it doesn't mistakenly say there are no remaining episodes.
+        when(() => mockRepository.getSeenStatus(2, MediaType.tv)).thenAnswer(
+          (_) async => [
+            SeenItem(
+              id: 11,
+              tmdbId: 2,
+              type: MediaType.tv,
+              title: 'Show',
+              seenDate: DateTime.now(),
+              seasonNumber: 3,
+              episodeNumber: 4,
+            ),
+          ],
+        );
+        when(
+          () => mockRepository.getMediaDetails(2, type: MediaType.tv),
+        ).thenAnswer(
+          (_) async => MediaDetails(
+            item: MediaItem(
+              id: 2,
+              title: 'Show',
+              overview: '',
+              releaseDate: '',
+              mediaType: MediaType.tv,
+              seasons: [TVSeason(id: 1, seasonNumber: 3, episodeCount: 10)],
+            ),
+            cast: [],
+          ),
+        );
+        when(() => mockRepository.getSeasonDetails(2, 3)).thenAnswer(
+          (_) async => {
+            'episodes': [
+              {
+                'episode_number': 5,
+                'air_date': DateTime.now()
+                    .subtract(const Duration(days: 1))
+                    .toIso8601String(),
+              },
+            ],
+          },
+        );
+
+        // Simulate marking season 3 episode 4
+        // The SeenManager uses widget.seasonNumber/episodeNumber to check, so we create a SeenManager for those via compact mode
+        // Rebuild with episode context
+        await tester.pumpWidget(
+          ChangeNotifierProvider<SearchProvider>.value(
+            value: searchProvider,
+            child: MaterialApp(
+              theme: DefaultLightPalette().toThemeData(),
+              home: Scaffold(
+                body: SeenManager(
+                  compact: false,
+                  item: MediaItem(
+                    id: 2,
+                    mediaType: MediaType.tv,
+                    title: 'Show',
+                    overview: '',
+                    releaseDate: '',
+                    status: 'Ended',
+                    lastSeasonNumber: 5,
+                    lastEpisodeNumber: 10,
+                  ),
+                  seasonNumber: 3,
+                  episodeNumber: 4,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await _markAsSeenViaUi(tester);
+
+        verifyNever(
+          () => mockRepository.removeFromList(2, MediaType.tv, 'watchlist'),
+        );
+      });
+
+      testWidgets('series end episode in watchlist is removed', (
+        WidgetTester tester,
+      ) async {
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => ['3:tv']);
+        await searchProvider.loadWatchlist();
+
+        when(
+          () => mockRepository.removeFromList(3, MediaType.tv, 'watchlist'),
+        ).thenAnswer((_) async => {});
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<SearchProvider>.value(
+            value: searchProvider,
+            child: MaterialApp(
+              theme: DefaultLightPalette().toThemeData(),
+              home: Scaffold(
+                body: SeenManager(
+                  compact: false,
+                  item: MediaItem(
+                    id: 3,
+                    mediaType: MediaType.tv,
+                    title: 'Finale',
+                    overview: '',
+                    releaseDate: '',
+                    status: 'Ended',
+                    lastSeasonNumber: 2,
+                    lastEpisodeNumber: 8,
+                  ),
+                  seasonNumber: 2,
+                  episodeNumber: 8,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        await _markAsSeenViaUi(tester);
+
+        verify(
+          () => mockRepository.removeFromList(3, MediaType.tv, 'watchlist'),
+        ).called(1);
+      });
+
+      testWidgets('series end episode not in watchlist does nothing', (
+        WidgetTester tester,
+      ) async {
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => []);
+        await searchProvider.loadWatchlist();
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<SearchProvider>.value(
+            value: searchProvider,
+            child: MaterialApp(
+              theme: DefaultLightPalette().toThemeData(),
+              home: Scaffold(
+                body: SeenManager(
+                  compact: false,
+                  item: MediaItem(
+                    id: 4,
+                    mediaType: MediaType.tv,
+                    title: 'NotSaved',
+                    overview: '',
+                    releaseDate: '',
+                    status: 'Ended',
+                    lastSeasonNumber: 1,
+                    lastEpisodeNumber: 1,
+                  ),
+                  seasonNumber: 1,
+                  episodeNumber: 1,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        when(
+          () => mockRepository.removeFromList(any(), any(), any()),
+        ).thenAnswer((_) async => {});
+
+        await _markAsSeenViaUi(tester);
+
+        verifyNever(() => mockRepository.removeFromList(any(), any(), any()));
+      });
+
+      testWidgets('series last episode but status not Ended does not remove', (
+        WidgetTester tester,
+      ) async {
+        when(
+          () => mockRepository.getWatchlistEntries(),
+        ).thenAnswer((_) async => ['5:tv']);
+        await searchProvider.loadWatchlist();
+
+        await tester.pumpWidget(
+          ChangeNotifierProvider<SearchProvider>.value(
+            value: searchProvider,
+            child: MaterialApp(
+              theme: DefaultLightPalette().toThemeData(),
+              home: Scaffold(
+                body: SeenManager(
+                  compact: false,
+                  item: MediaItem(
+                    id: 5,
+                    mediaType: MediaType.tv,
+                    title: 'Ongoing',
+                    overview: '',
+                    releaseDate: '',
+                    status: 'Returning Series',
+                    lastSeasonNumber: 1,
+                    lastEpisodeNumber: 10,
+                  ),
+                  seasonNumber: 1,
+                  episodeNumber: 10,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        when(
+          () => mockRepository.removeFromList(any(), any(), any()),
+        ).thenAnswer((_) async => {});
+
+        await _markAsSeenViaUi(tester);
+
+        verifyNever(() => mockRepository.removeFromList(any(), any(), any()));
       });
     });
   });


### PR DESCRIPTION
Closes #73 

- Update `SearchProvider.markAsSeen` to automatically remove a movie from the watchlist when it is marked as seen.
- Implement logic to remove TV series from the watchlist if the episode marked as seen is the series finale and the series status is discontinued (e.g., Ended, Cancelled).
- Refactor `SeenManager` to handle watchlist synchronization and improve code formatting.
- Add comprehensive widget tests for `SeenManager` and entry points (Notification Center, Watch Next, Quick Add) to verify automatic watchlist removal behavior.
- Clean up formatting and improve null safety/error handling in provider methods.