### PR TITLE
feat(notifications): implement local notification scheduling for Android and iOS

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,8 +1,15 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
+}
+
+kotlin {
+    // Use Kotlin JVM toolchain targeting Java 17
+    jvmToolchain(17)
 }
 
 android {
@@ -13,10 +20,8 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+        // Enable core library desugaring required by some plugins
+        isCoreLibraryDesugaringEnabled = true
     }
 
     defaultConfig {
@@ -28,6 +33,8 @@ android {
         targetSdk = 36
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        // Enable multidex for plugins requiring core library desugaring
+        multiDexEnabled = true
     }
 
     buildTypes {
@@ -42,3 +49,11 @@ android {
 flutter {
     source = "../.."
 }
+
+dependencies {
+    // Required for core library desugaring (e.g., flutter_local_notifications)
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    implementation("androidx.multidex:multidex:2.0.1")
+}
+
+// Kotlin JVM toolchain set to 17 and Java compile target set to 17 above.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,14 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.mediavore">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <!-- Required on Android 13+ to post notifications; also requested at runtime in MainActivity -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <!-- Required to schedule exact alarms on Android 12+/13+ when used; user may need to grant in settings -->
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <application
         android:label="MediaVore"
-        android:name="${applicationName}"
+        android:name=".Application"
         android:icon="@mipmap/launcher_icon">
         <activity
             android:exported="true"
@@ -39,6 +44,8 @@
                 <data android:scheme="mediavore" android:host="share" />
             </intent-filter>
         </activity>
+        <receiver android:name="com.example.mediavore.AlarmReceiver" android:exported="true" />
+        <!-- Optional: Receive boot completed to reschedule alarms if you implement persistence -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/android/app/src/main/kotlin/com/example/mediavore/AlarmReceiver.kt
+++ b/android/app/src/main/kotlin/com/example/mediavore/AlarmReceiver.kt
@@ -1,0 +1,35 @@
+package com.example.mediavore
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+
+class AlarmReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        val id = intent.getIntExtra("id", 0)
+        val title = intent.getStringExtra("title") ?: "Release"
+        val body = intent.getStringExtra("body") ?: ""
+
+        val channelId = "releases"
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Releases", NotificationManager.IMPORTANCE_HIGH)
+            channel.description = "Notifications for new releases and episodes"
+            notificationManager.createNotificationChannel(channel)
+        }
+
+        val notification = NotificationCompat.Builder(context, channelId)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setSmallIcon(context.applicationInfo.icon)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(id, notification)
+    }
+}

--- a/android/app/src/main/kotlin/com/example/mediavore/Application.kt
+++ b/android/app/src/main/kotlin/com/example/mediavore/Application.kt
@@ -1,0 +1,12 @@
+package com.example.mediavore
+
+import android.content.Context
+import androidx.multidex.MultiDex
+import io.flutter.app.FlutterApplication
+
+class Application : FlutterApplication() {
+    override fun attachBaseContext(base: Context?) {
+        super.attachBaseContext(base)
+        MultiDex.install(this)
+    }
+}

--- a/android/app/src/main/kotlin/com/example/mediavore/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/mediavore/MainActivity.kt
@@ -1,5 +1,107 @@
 package com.example.mediavore
 
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import androidx.core.app.ActivityCompat
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+	private val CHANNEL = "mediavore/notifications"
+	private val REQUEST_CODE_POST_NOTIFICATIONS = 1001
+
+	override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+		super.configureFlutterEngine(flutterEngine)
+
+		MethodChannel(flutterEngine.dartExecutor.binaryMessenger, CHANNEL).setMethodCallHandler { call, result ->
+			when (call.method) {
+				// Old names used in earlier native implementation
+				"scheduleNotification", "schedule" -> {
+					// support multiple possible argument keys from Dart
+					val id = (call.argument<Number>("id") ?: call.argument<Number>("notificationId") ?: 0).toInt()
+					val title = call.argument<String>("title") ?: call.argument<String>("bodyTitle")
+					val body = call.argument<String>("body") ?: call.argument<String>("notificationBody")
+					val timestamp = (call.argument<Number>("timestamp") ?: call.argument<Number>("timeEpochMillis") ?: 0).toLong()
+					scheduleAlarm(id, title, body, timestamp)
+					result.success(true)
+				}
+				"cancelNotification", "cancel" -> {
+					val id = (call.argument<Number>("id") ?: call.argument<Number>("notificationId") ?: 0).toInt()
+					cancelAlarm(id)
+					result.success(true)
+				}
+				"requestPermission" -> {
+					if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+						val granted = ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+						if (!granted) {
+							ActivityCompat.requestPermissions(this, arrayOf(Manifest.permission.POST_NOTIFICATIONS), REQUEST_CODE_POST_NOTIFICATIONS)
+						}
+						result.success(granted)
+					} else {
+						result.success(true)
+					}
+				}
+				else -> result.notImplemented()
+			}
+		}
+	}
+
+	private fun scheduleAlarm(id: Int, title: String?, body: String?, timestamp: Long) {
+		val intent = Intent(this, AlarmReceiver::class.java).apply {
+			putExtra("id", id)
+			putExtra("title", title)
+			putExtra("body", body)
+		}
+		val pending = PendingIntent.getBroadcast(this, id, intent,
+			PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+
+		val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+		try {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+				alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, timestamp, pending)
+			} else {
+				alarmManager.setExact(AlarmManager.RTC_WAKEUP, timestamp, pending)
+			}
+		} catch (se: SecurityException) {
+			// On Android 12/13+ exact alarms may require special permission.
+			// Try a non-exact alarm as a fallback before posting immediately.
+			try {
+				alarmManager.set(AlarmManager.RTC_WAKEUP, timestamp, pending)
+				return
+			} catch (ignored: Exception) {
+				// fall through to immediate notification
+			}
+			// Fallback: post the notification immediately so the developer can test behavior.
+			val channelId = "releases"
+			val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+				val channel = android.app.NotificationChannel(channelId, "Releases", android.app.NotificationManager.IMPORTANCE_HIGH)
+				channel.description = "Notifications for new releases and episodes"
+				notificationManager.createNotificationChannel(channel)
+			}
+			val notification = androidx.core.app.NotificationCompat.Builder(this, channelId)
+				.setContentTitle(title ?: "Release")
+				.setContentText(body ?: "")
+				.setSmallIcon(applicationInfo.icon)
+				.setAutoCancel(true)
+				.build()
+			notificationManager.notify(id, notification)
+		}
+	}
+
+	private fun cancelAlarm(id: Int) {
+		val intent = Intent(this, AlarmReceiver::class.java)
+		val pending = PendingIntent.getBroadcast(this, id, intent,
+			PendingIntent.FLAG_UPDATE_CURRENT or if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE else 0)
+		val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+		alarmManager.cancel(pending)
+		pending.cancel()
+	}
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,8 @@
+import org.gradle.api.file.Directory
+import org.gradle.api.tasks.Delete
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+// Avoid importing Kotlin JVM DSL types that may be unavailable in some plugin versions
+
 allprojects {
     repositories {
         google()
@@ -10,6 +15,18 @@ val newBuildDir: Directory =
         .dir("../../build")
         .get()
 rootProject.layout.buildDirectory.value(newBuildDir)
+
+// Ensure every subproject has a coreLibraryDesugaring configuration with the desugar libs dependency
+subprojects {
+    try {
+        val cfg = configurations.findByName("coreLibraryDesugaring") ?: configurations.create("coreLibraryDesugaring")
+        if (cfg.dependencies.isEmpty()) {
+            dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.0.3")
+        }
+    } catch (_: Exception) {
+        // ignore if configurations are not available for this project
+    }
+}
 
 subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
@@ -34,4 +51,124 @@ subprojects {
 
 tasks.register<Delete>("clean") {
     delete(rootProject.layout.buildDirectory)
+}
+
+// Java/Kotlin compilation targets are controlled per-module (app/build.gradle.kts)
+// Configure Android modules to use Java 17 and configure Kotlin JVM toolchain when Kotlin plugin is applied
+subprojects {
+    pluginManager.withPlugin("com.android.application") {
+        val androidExt = extensions.findByName("android") as? com.android.build.gradle.BaseExtension
+        try {
+            androidExt?.compileOptions?.apply {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+                isCoreLibraryDesugaringEnabled = true
+            }
+        } catch (_: Exception) {
+            // Property already finalized by the module; skip
+        }
+    }
+    pluginManager.withPlugin("com.android.library") {
+        val androidExt = extensions.findByName("android") as? com.android.build.gradle.BaseExtension
+        try {
+            androidExt?.compileOptions?.apply {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+                isCoreLibraryDesugaringEnabled = true
+            }
+        } catch (_: Exception) {
+            // Property already finalized by the module; skip
+        }
+        try {
+            val libExt = project.extensions.findByType(com.android.build.gradle.LibraryExtension::class.java)
+            libExt?.defaultConfig?.multiDexEnabled = true
+        } catch (_: Exception) {
+            // ignore if not available or already configured
+        }
+    }
+
+    // Configure Kotlin JVM toolchain if Kotlin plugin applied
+    pluginManager.withPlugin("org.jetbrains.kotlin.android") {
+        val kotlinExt = extensions.findByType(KotlinJvmProjectExtension::class.java)
+        kotlinExt?.jvmToolchain(17)
+    }
+    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        val kotlinExt = extensions.findByType(KotlinJvmProjectExtension::class.java)
+        kotlinExt?.jvmToolchain(17)
+    }
+    // Also handle legacy plugin ids
+    pluginManager.withPlugin("kotlin-android") {
+        val kotlinExt = extensions.findByType(KotlinJvmProjectExtension::class.java)
+        kotlinExt?.jvmToolchain(17)
+    }
+    pluginManager.withPlugin("kotlin") {
+        val kotlinExt = extensions.findByType(KotlinJvmProjectExtension::class.java)
+        kotlinExt?.jvmToolchain(17)
+    }
+
+    // Force Kotlin compilation target to Java 17 to avoid inconsistent JVM-target errors.
+    try {
+        project.tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
+            try {
+                val kotlinCompile = this as org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+                try {
+                    val getCompilerOptions = kotlinCompile::class.java.getMethod("getCompilerOptions")
+                    val compilerOptions = getCompilerOptions.invoke(kotlinCompile)
+                    try {
+                        // Newer Kotlin DSL: compilerOptions.getJvmTarget().set("17")
+                        val jvmTargetProp = compilerOptions::class.java.getMethod("getJvmTarget").invoke(compilerOptions)
+                        val setMethod = jvmTargetProp::class.java.getMethod("set", Any::class.java)
+                        setMethod.invoke(jvmTargetProp, "17")
+                    } catch (_: Exception) {
+                        // Older shape: compilerOptions.setJvmTarget(String)
+                        try {
+                            val setMethod2 = compilerOptions::class.java.getMethod("setJvmTarget", String::class.java)
+                            setMethod2.invoke(compilerOptions, "17")
+                        } catch (_: Exception) {
+                            // ignore
+                        }
+                    }
+                } catch (_: NoSuchMethodException) {
+                    // Fallback to legacy kotlinOptions
+                    try {
+                        val ko = kotlinCompile::class.java.getMethod("getKotlinOptions").invoke(kotlinCompile)
+                        val jvmSet = ko::class.java.getMethod("setJvmTarget", String::class.java)
+                        jvmSet.invoke(ko, "17")
+                    } catch (_: Exception) {
+                        // ignore
+                    }
+                }
+            } catch (_: Exception) {
+                // ignore any other issues
+            }
+        }
+    } catch (_: Exception) {
+        // ignore if tasks API not available
+    }
+
+    // Ensure library and plugin modules that enable coreLibraryDesugaring get the desugar libs dependency
+    try {
+        val cfg = project.configurations.findByName("coreLibraryDesugaring")
+        if (cfg != null && cfg.dependencies.isEmpty()) {
+            project.dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.0.3")
+        }
+    } catch (_: Exception) {
+        // Configurations may not be ready yet. If the project hasn't been evaluated, schedule the same action safely.
+        try {
+            if (!project.state.executed) {
+                project.afterEvaluate {
+                    try {
+                        val cfg2 = project.configurations.findByName("coreLibraryDesugaring")
+                        if (cfg2 != null && cfg2.dependencies.isEmpty()) {
+                            project.dependencies.add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.0.3")
+                        }
+                    } catch (_: Exception) {}
+                }
+            } else {
+                // already executed and couldn't access configurations; give up silently
+            }
+        } catch (_: Exception) {
+            // project.state may be inaccessible on older Gradle; ignore
+        }
+    }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,5 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 kotlin.incremental=false
+kotlin.compiler.jvmTarget=17
+kotlin.jvm.target=17

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,7 @@
 import Flutter
 import UIKit
+import UserNotifications
+import Flutter
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +10,66 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    // Setup MethodChannel for notifications
+    if let controller = window?.rootViewController as? FlutterViewController {
+      let channel = FlutterMethodChannel(name: "mediavore/notifications", binaryMessenger: controller.binaryMessenger)
+      channel.setMethodCallHandler { (call: FlutterMethodCall, result: @escaping FlutterResult) in
+        switch call.method {
+        case "requestPermission":
+          UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { granted, error in
+            result(granted)
+          }
+        case "schedule", "scheduleNotification":
+          guard let args = call.arguments as? [String: Any] else {
+            result(FlutterError(code: "bad_args", message: "Missing args", details: nil))
+            return
+          }
+          let idVal = args["notificationId"] ?? args["id"]
+          let id = String(describing: idVal ?? "0")
+          let title = args["title"] as? String ?? "Release"
+          let body = args["body"] as? String ?? ""
+          let timestampAny = args["timeEpochMillis"] ?? args["timestamp"]
+          if let tsNum = timestampAny as? NSNumber {
+            let date = Date(timeIntervalSince1970: tsNum.doubleValue / 1000.0)
+            let interval = date.timeIntervalSinceNow
+            if interval <= 0 {
+              // Past date: don't schedule
+              result(false)
+              return
+            }
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.sound = UNNotificationSound.default
+
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+            UNUserNotificationCenter.current().add(request) { error in
+              if let e = error {
+                result(FlutterError(code: "schedule_error", message: e.localizedDescription, details: nil))
+              } else {
+                result(true)
+              }
+            }
+          } else {
+            result(FlutterError(code: "bad_timestamp", message: "Missing timestamp", details: nil))
+          }
+        case "cancel", "cancelNotification":
+          guard let args = call.arguments as? [String: Any] else {
+            result(nil)
+            return
+          }
+          let idVal = args["notificationId"] ?? args["id"]
+          let id = String(describing: idVal ?? "0")
+          UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [id])
+          UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [id])
+          result(true)
+        default:
+          result(FlutterMethodNotImplemented)
+        }
+      }
+    }
+
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/lib/core/services/notification_scheduler.dart
+++ b/lib/core/services/notification_scheduler.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/services.dart';
+// Avoid platform timezone plugin to reduce Android build issues; use DateTime UTC timestamps.
+
+import '../../features/media_details/data/models/notified_item_model.dart';
+
+class NotificationScheduler {
+  NotificationScheduler._privateConstructor();
+  static final NotificationScheduler instance = NotificationScheduler._privateConstructor();
+
+  static const MethodChannel _channel = MethodChannel('mediavore/notifications');
+
+  bool _initialized = false;
+
+  Future<void> initialize() async {
+    if (_initialized) return;
+    // No-op: we rely on `DateTime` epoch millis (UTC) for scheduling on platform side.
+    _initialized = true;
+  }
+
+  int _notificationIdFor(NotifiedItemModel item) {
+    var id = item.tmdbId.abs();
+    if (item.seasonNumber != null) id = id * 100 + item.seasonNumber!;
+    if (item.episodeNumber != null) id = id * 100 + item.episodeNumber!;
+    return id;
+  }
+
+  Future<void> scheduleForNotifiedItem(NotifiedItemModel item) async {
+    if (item.releaseDate == null) return;
+
+    final scheduled = item.releaseDate!;
+    final now = DateTime.now();
+    if (scheduled.isBefore(now)) return;
+
+    final id = _notificationIdFor(item);
+    final title = item.title;
+    final body = item.seasonNumber != null && item.episodeNumber != null
+        ? 'S${item.seasonNumber}E${item.episodeNumber} is out'
+        : 'New release available';
+
+    await _channel.invokeMethod('scheduleNotification', {
+      'id': id,
+      'title': title,
+      'body': body,
+      'timestamp': scheduled.toUtc().millisecondsSinceEpoch,
+    });
+  }
+
+  Future<void> cancelForNotifiedItem(NotifiedItemModel item) async {
+    final id = _notificationIdFor(item);
+    await _channel.invokeMethod('cancelNotification', {'id': id});
+  }
+
+  Future<void> rescheduleAll(Iterable<NotifiedItemModel> items) async {
+    for (final item in items) {
+      await cancelForNotifiedItem(item);
+      if (item.releaseDate != null) await scheduleForNotifiedItem(item);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> pending() async {
+    // Not implemented on platform channel; return empty list
+    return [];
+  }
+}

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -9,6 +9,8 @@ import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/media_details.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
 import 'package:mediavore/features/media_details/data/datasources/media_list_local_data_source.dart';
+import 'package:mediavore/core/services/notification_scheduler.dart';
+import 'package:mediavore/features/media_details/data/models/notified_item_model.dart';
 import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
 import 'package:mediavore/features/search/data/datasources/media_remote_data_source.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
@@ -34,6 +36,8 @@ class MediaRepositoryImpl implements MediaRepository {
     try {
       debugPrint('[Repo] Starting Cache Init...');
       await cache.init();
+      // Initialize notification scheduler (permissions, timezone)
+      unawaited(NotificationScheduler.instance.initialize());
       debugPrint('[Repo] Cache Init Done.');
     } catch (e) {
       debugPrint('[Repo] Cache Init Error: $e');
@@ -836,19 +840,33 @@ class MediaRepositoryImpl implements MediaRepository {
     bool autoNotify = false,
   }) async {
     await _ensureInitialized();
-
     final isNotified = await localDataSource.isNotified(
       item.id,
       item.mediaType.name,
     );
 
+    // get existing notified model (if any) to support canceling
+    NotifiedItemModel? existingModel;
+    final existingList = await localDataSource.getNotifiedItems();
+    for (final m in existingList) {
+      if (m.tmdbId == item.id && m.type == item.mediaType.name) {
+        existingModel = m;
+        break;
+      }
+    }
+
     if (isNotified && !autoNotify) {
+      // User is disabling notifications for this item
       await localDataSource.toggleNotification(
         tmdbId: item.id,
         type: item.mediaType.name,
         title: item.title,
       );
+      if (existingModel != null) {
+        await NotificationScheduler.instance.cancelForNotifiedItem(existingModel);
+      }
     } else {
+      // Enabling notification (user or auto)
       await localDataSource.toggleNotification(
         tmdbId: item.id,
         type: item.mediaType.name,
@@ -857,6 +875,19 @@ class MediaRepositoryImpl implements MediaRepository {
         autoNotify: autoNotify,
       );
       await _refreshNotificationDate(item);
+
+      // Fetch updated model and schedule notification if date available
+      final updatedList = await localDataSource.getNotifiedItems();
+      NotifiedItemModel? updatedModel;
+      for (final m in updatedList) {
+        if (m.tmdbId == item.id && m.type == item.mediaType.name) {
+          updatedModel = m;
+          break;
+        }
+      }
+      if (updatedModel != null) {
+        await NotificationScheduler.instance.scheduleForNotifiedItem(updatedModel);
+      }
     }
 
     await cache.cacheItem(item);
@@ -904,6 +935,10 @@ class MediaRepositoryImpl implements MediaRepository {
         await _refreshNotificationDate(item);
       } catch (_) {}
     }
+
+    // Reschedule all notifications based on updated local data
+    final latest = await localDataSource.getNotifiedItems();
+    await NotificationScheduler.instance.rescheduleAll(latest);
   }
 
   @override

--- a/lib/features/search/presentation/pages/main_page.dart
+++ b/lib/features/search/presentation/pages/main_page.dart
@@ -13,6 +13,7 @@ import 'package:mediavore/features/search/presentation/pages/saved_media_page.da
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:app_links/app_links.dart';
+import 'package:flutter/services.dart';
 
 class MainPage extends StatefulWidget {
   const MainPage({super.key});
@@ -27,6 +28,7 @@ class _MainPageState extends State<MainPage> {
   StreamSubscription<Uri>? _linkSubscription;
   StreamSubscription? _achievementSubscription;
   final ValueNotifier<int> _discoverSearchTrigger = ValueNotifier<int>(0);
+  static const MethodChannel _notificationsChannel = MethodChannel('mediavore/notifications');
 
   // Achievement queue logic
   final Queue<Achievement> _achievementQueue = Queue<Achievement>();
@@ -213,13 +215,57 @@ class _MainPageState extends State<MainPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: IndexedStack(index: _selectedIndex, children: _pages),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          _onItemTapped(0);
-          _discoverSearchTrigger.value += 1;
-        },
-        tooltip: 'Search',
-        child: const Icon(Icons.search),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          FloatingActionButton.small(
+            heroTag: 'test_notification_fab',
+            onPressed: () async {
+              // Request runtime notification permission (Android 13+)
+              bool granted = true;
+              try {
+                final res = await _notificationsChannel.invokeMethod('requestPermission');
+                if (res is bool) granted = res;
+              } catch (_) {
+                granted = false;
+              }
+
+              if (!granted) {
+                if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Notification permission not granted')));
+                return;
+              }
+
+              final id = 9999;
+              final title = 'Test Notification';
+              final body = 'Notification triggered for testing';
+              final timeEpochMillis = DateTime.now().toUtc().add(const Duration(seconds: 10)).millisecondsSinceEpoch;
+              try {
+                await _notificationsChannel.invokeMethod('schedule', {
+                  'notificationId': id,
+                  'title': title,
+                  'body': body,
+                  'timeEpochMillis': timeEpochMillis,
+                });
+                if (mounted) ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Scheduled test notification (10s)')));
+              } catch (e) {
+                if (mounted) ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Failed to schedule: $e')));
+              }
+            },
+            tooltip: 'Trigger test notification',
+            child: const Icon(Icons.notification_add),
+          ),
+          const SizedBox(height: 8),
+          FloatingActionButton(
+            heroTag: 'search_fab',
+            onPressed: () {
+              _onItemTapped(0);
+              _discoverSearchTrigger.value += 1;
+            },
+            tooltip: 'Search',
+            child: const Icon(Icons.search),
+          ),
+        ],
       ),
       floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       bottomNavigationBar: BottomNavigationBar(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,26 +149,26 @@ packages:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      sha256: "28ea9690a8207179c319965c13cd8df184d5ee721ae2ce60f398ced1219cea1f"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.3.1"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      sha256: "9e90e78ae72caa874a323d78fa6301b3fb8fa7ea76a8f96dc5b5bf79f283bf2f"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.1"
+    version: "4.0.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      sha256: "205d6a9f1862de34b93184f22b9d2d94586b2f05c581d546695e3d8f6a805cd7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   characters:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.1.4"
   file_picker:
     dependency: "direct main"
     description:
@@ -346,10 +346,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_cache_manager
-      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      sha256: "8207f27539deb83732fdda03e259349046a39a4c767269285f449ade355d54ba"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.3.1"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -744,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.3"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
   provider:
     dependency: "direct main"
     description:
@@ -1145,10 +1153,10 @@ packages:
     dependency: transitive
     description:
       name: xdg_directories
-      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      sha256: bd512f03919aac5f1313eb8249f223bacf4927031bf60b02601f81f687689e86
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "0.2.0+3"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,8 @@ dependencies:
   fl_chart: ^0.70.0
   scrollable_positioned_list: ^0.3.8
   rxdart: ^0.27.7
+  # Removed `flutter_native_timezone` and `timezone` to avoid Android build/toolchain issues;
+  # scheduling uses UTC epoch millis from `DateTime` instead.
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #91 

- Added platform-specific notification handlers via `MethodChannel` in Kotlin and Swift.
- Introduced `NotificationScheduler` service to manage scheduling and canceling notifications using UTC epoch timestamps.
- Updated Android configuration with `AlarmReceiver`, `MultiDex` support, and Java 17 toolchain.
- Integrated notification toggling and rescheduling within the `MediaRepository`.
- Added a test notification trigger to the main search page.