### PR TITLE
feat(quick_add): implement persistent Quick Add for TV series streaks

### DIFF
--- a/lib/core/database/app_database.dart
+++ b/lib/core/database/app_database.dart
@@ -6,6 +6,8 @@ import 'package:mediavore/features/media_details/data/models/media_list_item.dar
 import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
 import 'package:mediavore/features/media_details/data/models/liked_item.dart';
 import 'package:mediavore/features/media_details/data/models/notified_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_opt_out_model.dart';
 import 'package:mediavore/features/achievements/data/models/achievement_model.dart';
 import 'package:mediavore/core/cache/cached_media.dart';
 
@@ -21,6 +23,8 @@ abstract class DatabaseModule {
       SeenItemModelSchema,
       LikedItemSchema,
       NotifiedItemModelSchema,
+      QuickAddItemModelSchema,
+      QuickAddOptOutModelSchema,
       CachedMediaSchema,
       CachedActorProfileSchema,
       CachedSeasonSchema,

--- a/lib/core/di/asset_definitions_loader.dart
+++ b/lib/core/di/asset_definitions_loader.dart
@@ -1,0 +1,16 @@
+import 'dart:convert';
+import 'package:injectable/injectable.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:mediavore/core/di/definitions_loader.dart';
+
+@LazySingleton(as: DefinitionsLoader)
+class AssetDefinitionsLoader implements DefinitionsLoader {
+  static const _assetPath = 'assets/achievements/definitions.json';
+
+  @override
+  Future<List<Map<String, dynamic>>> load() async {
+    final jsonStr = await rootBundle.loadString(_assetPath);
+    final list = jsonDecode(jsonStr) as List<dynamic>;
+    return list.map((e) => Map<String, dynamic>.from(e as Map)).toList();
+  }
+}

--- a/lib/core/di/definitions_loader.dart
+++ b/lib/core/di/definitions_loader.dart
@@ -1,0 +1,3 @@
+abstract class DefinitionsLoader {
+  Future<List<Map<String, dynamic>>> load();
+}

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -8,28 +8,31 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:dio/dio.dart' as _i3;
+import 'package:dio/dio.dart' as _i5;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i4;
-import 'package:shared_preferences/shared_preferences.dart' as _i10;
+import 'package:isar/isar.dart' as _i6;
+import 'package:shared_preferences/shared_preferences.dart' as _i12;
 
 import '../../features/achievements/data/repositories/achievement_repository_impl.dart'
-    as _i12;
+    as _i14;
 import '../../features/achievements/domain/repositories/achievement_repository.dart'
-    as _i11;
-import '../../features/achievements/presentation/providers/achievement_provider.dart'
     as _i13;
+import '../../features/achievements/presentation/providers/achievement_provider.dart'
+    as _i15;
 import '../../features/media_details/data/datasources/media_list_local_data_source.dart'
-    as _i6;
+    as _i8;
 import '../../features/search/data/datasources/media_remote_data_source.dart'
-    as _i7;
-import '../../features/search/data/repositories/media_repository_impl.dart'
     as _i9;
-import '../../features/search/domain/repositories/media_repository.dart' as _i8;
-import '../cache/media_cache.dart' as _i5;
-import '../database/app_database.dart' as _i15;
-import 'injection.dart' as _i14;
+import '../../features/search/data/repositories/media_repository_impl.dart'
+    as _i11;
+import '../../features/search/domain/repositories/media_repository.dart'
+    as _i10;
+import '../cache/media_cache.dart' as _i7;
+import '../database/app_database.dart' as _i17;
+import 'asset_definitions_loader.dart' as _i4;
+import 'definitions_loader.dart' as _i3;
+import 'injection.dart' as _i16;
 
 // initializes the registration of main-scope dependencies inside of GetIt
 Future<_i1.GetIt> init(
@@ -37,45 +40,47 @@ Future<_i1.GetIt> init(
   String? environment,
   _i2.EnvironmentFilter? environmentFilter,
 }) async {
-  final gh = _i2.GetItHelper(getIt, environment, environmentFilter);
+  final gh = _i2.GetItHelper(
+    getIt,
+    environment,
+    environmentFilter,
+  );
   final registerModule = _$RegisterModule();
   final databaseModule = _$DatabaseModule();
-  gh.singleton<_i3.Dio>(() => registerModule.dio);
-  await gh.singletonAsync<_i4.Isar>(
+  gh.lazySingleton<_i3.DefinitionsLoader>(() => _i4.AssetDefinitionsLoader());
+  gh.singleton<_i5.Dio>(() => registerModule.dio);
+  await gh.singletonAsync<_i6.Isar>(
     () => databaseModule.isar,
     preResolve: true,
   );
-  gh.lazySingleton<_i5.MediaCache>(() => _i5.MediaCache(gh<_i4.Isar>()));
-  gh.lazySingleton<_i6.MediaListLocalDataSource>(
-    () => _i6.MediaListLocalDataSource(gh<_i4.Isar>()),
-  );
-  gh.lazySingleton<_i7.MediaRemoteDataSource>(
-    () => _i7.MediaRemoteDataSource(dio: gh<_i3.Dio>(), apiToken: gh<String>()),
-  );
-  gh.lazySingleton<_i8.MediaRepository>(
-    () => _i9.MediaRepositoryImpl(
-      remoteDataSource: gh<_i7.MediaRemoteDataSource>(),
-      localDataSource: gh<_i6.MediaListLocalDataSource>(),
-      cache: gh<_i5.MediaCache>(),
-    ),
-  );
-  await gh.factoryAsync<_i10.SharedPreferences>(
+  gh.lazySingleton<_i7.MediaCache>(() => _i7.MediaCache(gh<_i6.Isar>()));
+  gh.lazySingleton<_i8.MediaListLocalDataSource>(
+      () => _i8.MediaListLocalDataSource(gh<_i6.Isar>()));
+  gh.lazySingleton<_i9.MediaRemoteDataSource>(() => _i9.MediaRemoteDataSource(
+        dio: gh<_i5.Dio>(),
+        apiToken: gh<String>(),
+      ));
+  gh.lazySingleton<_i10.MediaRepository>(() => _i11.MediaRepositoryImpl(
+        remoteDataSource: gh<_i9.MediaRemoteDataSource>(),
+        localDataSource: gh<_i8.MediaListLocalDataSource>(),
+        cache: gh<_i7.MediaCache>(),
+      ));
+  await gh.factoryAsync<_i12.SharedPreferences>(
     () => registerModule.sharedPreferences,
     preResolve: true,
   );
   gh.singleton<String>(() => registerModule.apiToken);
-  gh.lazySingleton<_i11.AchievementRepository>(
-    () => _i12.AchievementRepositoryImpl(
-      gh<_i4.Isar>(),
-      gh<_i6.MediaListLocalDataSource>(),
-    ),
-  );
-  gh.lazySingleton<_i13.AchievementProvider>(
-    () => _i13.AchievementProvider(gh<_i11.AchievementRepository>()),
-  );
+  gh.lazySingleton<_i13.AchievementRepository>(
+      () => _i14.AchievementRepositoryImpl(
+            gh<_i6.Isar>(),
+            gh<_i8.MediaListLocalDataSource>(),
+            definitionsLoader: gh<_i3.DefinitionsLoader>(),
+          ));
+  gh.lazySingleton<_i15.AchievementProvider>(
+      () => _i15.AchievementProvider(gh<_i13.AchievementRepository>()));
   return getIt;
 }
 
-class _$RegisterModule extends _i14.RegisterModule {}
+class _$RegisterModule extends _i16.RegisterModule {}
 
-class _$DatabaseModule extends _i15.DatabaseModule {}
+class _$DatabaseModule extends _i17.DatabaseModule {}

--- a/lib/features/achievements/data/repositories/achievement_repository_impl.dart
+++ b/lib/features/achievements/data/repositories/achievement_repository_impl.dart
@@ -8,13 +8,14 @@ import 'package:mediavore/features/media_details/data/models/seen_item_model.dar
 import 'dart:convert';
 
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:mediavore/core/di/definitions_loader.dart';
 import 'package:rxdart/rxdart.dart';
 
 @LazySingleton(as: AchievementRepository)
 class AchievementRepositoryImpl implements AchievementRepository {
   final Isar _isar;
   final MediaListLocalDataSource _localDataSource;
-  final Future<List<Map<String, dynamic>>> Function()? definitionsLoader;
+  final DefinitionsLoader? definitionsLoader;
 
   AchievementRepositoryImpl(
     this._isar,
@@ -101,7 +102,7 @@ class AchievementRepositoryImpl implements AchievementRepository {
     // If a loader was injected (tests or alternative runtime), use it first.
     if (definitionsLoader != null) {
       try {
-        return await definitionsLoader!();
+        return await definitionsLoader!.load();
       } catch (_) {
         // fall through to asset loader
       }

--- a/lib/features/media_details/data/datasources/media_list_local_data_source.dart
+++ b/lib/features/media_details/data/datasources/media_list_local_data_source.dart
@@ -5,6 +5,8 @@ import 'package:mediavore/features/media_details/data/models/user_list.dart';
 import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
 import 'package:mediavore/features/media_details/data/models/liked_item.dart';
 import 'package:mediavore/features/media_details/data/models/notified_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_opt_out_model.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 
 @lazySingleton
@@ -396,6 +398,121 @@ class MediaListLocalDataSource {
         .tmdbIdEqualTo(tmdbId)
         .typeEqualTo(type)
         .count();
+    return count > 0;
+  }
+
+  // QuickAdd methods
+  Future<List<QuickAddItemModel>> getQuickAddItems() async {
+    return await _isar.quickAddItemModels.where().sortByInsertedAtDesc().findAll();
+  }
+
+  Future<void> addQuickAddItem(QuickAddItemModel item) async {
+    await _isar.writeTxn(() async {
+      // avoid duplicates for same tmdb/season/episode
+      final existingCount = await _isar.quickAddItemModels
+          .filter()
+          .tmdbIdEqualTo(item.tmdbId)
+          .seasonNumberEqualTo(item.seasonNumber)
+          .episodeNumberEqualTo(item.episodeNumber)
+          .count();
+      if (existingCount == 0) {
+        await _isar.quickAddItemModels.put(item);
+      }
+    });
+  }
+
+  Future<void> removeQuickAddItemById(int isarId) async {
+    await _isar.writeTxn(() async {
+      await _isar.quickAddItemModels.delete(isarId);
+    });
+  }
+
+  Future<void> removeQuickAddItemsByTmdb(int tmdbId) async {
+    await _isar.writeTxn(() async {
+      await _isar.quickAddItemModels.filter().tmdbIdEqualTo(tmdbId).deleteAll();
+    });
+  }
+
+  Future<void> clearQuickAddItems() async {
+    await _isar.writeTxn(() async {
+      await _isar.quickAddItemModels.clear();
+    });
+  }
+
+  Future<void> removeQuickAddItemByTmdbSeasonEpisode(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await _isar.writeTxn(() async {
+      var query = _isar.quickAddItemModels.filter().tmdbIdEqualTo(tmdbId);
+      if (seasonNumber != null) {
+        query = query.seasonNumberEqualTo(seasonNumber);
+      }
+      if (episodeNumber != null) {
+        query = query.episodeNumberEqualTo(episodeNumber);
+      }
+      await query.deleteAll();
+    });
+  }
+
+  // Opt-out methods
+  Future<void> addOptOut(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await _isar.writeTxn(() async {
+      final existingQuery = _isar.quickAddOptOutModels.filter().tmdbIdEqualTo(tmdbId);
+      final existing = await (seasonNumber != null && episodeNumber != null
+              ? existingQuery
+                  .and()
+                  .seasonNumberEqualTo(seasonNumber)
+                  .episodeNumberEqualTo(episodeNumber)
+                  .findFirst()
+              : existingQuery.findFirst());
+
+      if (existing == null) {
+        await _isar.quickAddOptOutModels.put(
+          QuickAddOptOutModel(
+            tmdbId: tmdbId,
+            seasonNumber: seasonNumber,
+            episodeNumber: episodeNumber,
+            optedOutAt: DateTime.now(),
+          ),
+        );
+      }
+
+      // remove only quick-add entries matching this streak (if provided) or the tmdbId+nulls
+      var q = _isar.quickAddItemModels.filter().tmdbIdEqualTo(tmdbId);
+      if (seasonNumber != null) q = q.seasonNumberEqualTo(seasonNumber);
+      if (episodeNumber != null) q = q.episodeNumberEqualTo(episodeNumber);
+      await q.deleteAll();
+    });
+  }
+
+  Future<void> removeOptOut(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await _isar.writeTxn(() async {
+      var q = _isar.quickAddOptOutModels.filter().tmdbIdEqualTo(tmdbId);
+      if (seasonNumber != null) q = q.and().seasonNumberEqualTo(seasonNumber);
+      if (episodeNumber != null) q = q.and().episodeNumberEqualTo(episodeNumber);
+      await q.deleteAll();
+    });
+  }
+
+  Future<bool> isOptedOut(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    var q = _isar.quickAddOptOutModels.filter().tmdbIdEqualTo(tmdbId);
+    if (seasonNumber != null) q = q.and().seasonNumberEqualTo(seasonNumber);
+    if (episodeNumber != null) q = q.and().episodeNumberEqualTo(episodeNumber);
+    final count = await q.count();
     return count > 0;
   }
 

--- a/lib/features/media_details/data/models/quick_add_item_model.dart
+++ b/lib/features/media_details/data/models/quick_add_item_model.dart
@@ -1,0 +1,33 @@
+import 'package:isar/isar.dart';
+
+part 'quick_add_item_model.g.dart';
+
+@collection
+class QuickAddItemModel {
+  Id? isarId;
+
+  final int tmdbId;
+
+  final String type;
+
+  final int? seasonNumber;
+  final int? episodeNumber;
+
+  final DateTime insertedAt;
+  final DateTime? airDate;
+
+  final String? title;
+  final String? posterPath;
+
+  QuickAddItemModel({
+    this.isarId,
+    required this.tmdbId,
+    required this.type,
+    this.seasonNumber,
+    this.episodeNumber,
+    required this.insertedAt,
+    this.airDate,
+    this.title,
+    this.posterPath,
+  });
+}

--- a/lib/features/media_details/data/models/quick_add_opt_out_model.dart
+++ b/lib/features/media_details/data/models/quick_add_opt_out_model.dart
@@ -1,0 +1,23 @@
+import 'package:isar/isar.dart';
+
+part 'quick_add_opt_out_model.g.dart';
+
+@collection
+class QuickAddOptOutModel {
+  Id? isarId;
+
+  final int tmdbId;
+
+  final int? seasonNumber;
+  final int? episodeNumber;
+
+  final DateTime optedOutAt;
+
+  QuickAddOptOutModel({
+    this.isarId,
+    required this.tmdbId,
+    this.seasonNumber,
+    this.episodeNumber,
+    required this.optedOutAt,
+  });
+}

--- a/lib/features/media_details/presentation/pages/notification_center_page.dart
+++ b/lib/features/media_details/presentation/pages/notification_center_page.dart
@@ -39,7 +39,7 @@ class NotificationCenterPageState extends State<NotificationCenterPage>
     await provider.refreshNotifiedItems(); // Refresh dates from network
     await provider.loadNotifiedItems();
     await provider.loadAllSeenStatus();
-    _quickAddKey.currentState?.loadNextEpisodes();
+    await provider.loadQuickAddItems();
   }
 
   @override
@@ -294,10 +294,7 @@ class _ReleasesTabState extends State<_ReleasesTab> {
                           item.type,
                         );
                         if (context.mounted) {
-                          await MediaDetailPage.show(
-                            context,
-                            details.item,
-                          );
+                          await MediaDetailPage.show(context, details.item);
                         }
                       },
                     );
@@ -318,50 +315,15 @@ class _QuickAddTab extends StatefulWidget {
 }
 
 class _QuickAddTabState extends State<_QuickAddTab> {
-  final Map<int, ({int seasonNumber, int episodeNumber})?> _nextEpisodes = {};
-  bool _isLoading = true;
-
-  @override
-  void initState() {
-    super.initState();
-    loadNextEpisodes();
-  }
-
-  Future<void> loadNextEpisodes() async {
-    if (!mounted) return;
-    setState(() => _isLoading = true);
-
-    final provider = context.read<SearchProvider>();
-    final seenSeries = provider.seenItems
-        .where((s) => s.type == MediaType.tv)
-        .map((s) => s.tmdbId)
-        .toSet();
-
-    for (final id in seenSeries) {
-      final next = await provider.getNextEpisode(id);
-      _nextEpisodes[id] = next;
-    }
-
-    if (mounted) {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    if (_isLoading) return const Center(child: CircularProgressIndicator());
-
     return Consumer<SearchProvider>(
       builder: (context, provider, child) {
-        final seriesToDisplay = _nextEpisodes.entries
-            .where((e) => e.value != null)
-            .toList();
+        final items = provider.quickAddItems;
 
         return RefreshIndicator(
           onRefresh: widget.onRefresh,
-          child: seriesToDisplay.isEmpty
+          child: items.isEmpty
               ? ListView(
                   children: const [
                     SizedBox(height: 100),
@@ -370,60 +332,113 @@ class _QuickAddTabState extends State<_QuickAddTab> {
                 )
               : ListView.builder(
                   padding: const EdgeInsets.only(bottom: 80),
-                  itemCount: seriesToDisplay.length,
+                  itemCount: items.length,
                   itemBuilder: (context, index) {
-                    final entry = seriesToDisplay[index];
-                    final tmdbId = entry.key;
-                    final nextEp = entry.value!;
+                    final qa = items[index];
+                    final tmdbId = qa.tmdbId;
+                    final title = qa.title ?? 'Unknown';
+                    final posterPath = qa.posterPath;
 
-                    final title = provider.seenItems
-                        .firstWhere((s) => s.tmdbId == tmdbId)
-                        .title;
-                    final posterPath = provider.seenItems
-                        .firstWhere((s) => s.tmdbId == tmdbId)
-                        .posterPath;
+                    String subtitle = '';
+                    if (qa.seasonNumber != null && qa.episodeNumber != null) {
+                      subtitle =
+                          'Next: Season ${qa.seasonNumber}, Episode ${qa.episodeNumber}';
+                    }
 
-                    return ListTile(
-                      leading: posterPath != null
-                          ? Image.network(
-                              'https://image.tmdb.org/t/p/w92$posterPath',
-                            )
-                          : const Icon(Icons.tv),
-                      title: Text(title),
-                      subtitle: Text(
-                        'Next: Season ${nextEp.seasonNumber}, Episode ${nextEp.episodeNumber}',
+                    final dismissKey =
+                        '${qa.tmdbId}-${qa.seasonNumber ?? 0}-${qa.episodeNumber ?? 0}-${qa.insertedAt.millisecondsSinceEpoch}';
+
+                    return Dismissible(
+                      key: ValueKey(dismissKey),
+                      direction: DismissDirection.endToStart,
+                      background: Container(
+                        color: Colors.redAccent,
+                        alignment: Alignment.centerRight,
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: const Icon(Icons.block, color: Colors.white),
                       ),
-                      trailing: IconButton(
-                        icon: const Icon(
-                          Icons.check_circle_outline,
-                          color: Colors.green,
-                        ),
-                        onPressed: () async {
-                          final seenItem = provider.seenItems.firstWhere(
-                            (s) => s.tmdbId == tmdbId,
-                          );
-                          await provider.markAsSeen(
-                            seenItem.copyWith(
-                              seenDate: DateTime.now(),
-                              seasonNumber: nextEp.seasonNumber,
-                              episodeNumber: nextEp.episodeNumber,
-                            ),
-                          );
-                          loadNextEpisodes();
-                        },
-                      ),
-                      onTap: () async {
-                        final details = await provider.getMediaDetails(
-                          tmdbId,
-                          MediaType.tv,
-                        );
-                        if (context.mounted) {
-                          await MediaDetailPage.show(
-                            context,
-                            details.item,
-                          );
-                        }
+                      confirmDismiss: (direction) async {
+                        return true; // allow swipe; perform opt-out in onDismissed to show Undo
                       },
+                      onDismissed: (direction) async {
+                        try {
+                          await provider.optOutSeries(
+                            tmdbId,
+                            seasonNumber: qa.seasonNumber,
+                            episodeNumber: qa.episodeNumber,
+                          );
+                          await provider.loadQuickAddItems();
+                          if (context.mounted) {
+                            final messenger = ScaffoldMessenger.of(context);
+                            // Remove any existing SnackBar immediately so the new one appears
+                            messenger.removeCurrentSnackBar();
+                            messenger.showSnackBar(
+                              SnackBar(
+                                content: const Text('Streak opted out of Quick Add'),
+                                duration: const Duration(seconds: 4),
+                                action: SnackBarAction(
+                                  label: 'Undo',
+                                  onPressed: () async {
+                                    try {
+                                      await provider.clearOptOutSeries(
+                                        tmdbId,
+                                        seasonNumber: qa.seasonNumber,
+                                        episodeNumber: qa.episodeNumber,
+                                      );
+                                      // Restore the exact dismissed quick-add entry directly
+                                      await provider.addQuickAddItem(qa);
+                                    } catch (_) {}
+                                  },
+                                ),
+                              ),
+                            );
+                          }
+                        } catch (_) {}
+                      },
+                      child: ListTile(
+                        leading: posterPath != null
+                            ? Image.network(
+                                'https://image.tmdb.org/t/p/w92$posterPath',
+                              )
+                            : const Icon(Icons.tv),
+                        title: Text(title),
+                        subtitle: Text(subtitle),
+                        trailing: IconButton(
+                          icon: const Icon(
+                            Icons.check_circle_outline,
+                            color: Colors.green,
+                          ),
+                          onPressed: () async {
+                            await provider.markAsSeen(
+                              SeenItem(
+                                tmdbId: qa.tmdbId,
+                                type: qa.type,
+                                title: qa.title ?? '',
+                                posterPath: qa.posterPath,
+                                seenDate: DateTime.now(),
+                                seasonNumber: qa.seasonNumber,
+                                episodeNumber: qa.episodeNumber,
+                              ),
+                            );
+                            await provider.loadQuickAddItems();
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Marked ${qa.title ?? 'episode'} as seen')),
+                              );
+                            }
+                          },
+                        ),
+                        onTap: () async {
+                          final details = await provider.getMediaDetails(
+                            qa.tmdbId,
+                            qa.type,
+                          );
+                          if (context.mounted) {
+                            await MediaDetailPage.show(context, details.item);
+                          }
+                        },
+                        // Long-press removed; swipe-to-dismiss handles opt-out.
+                      ),
                     );
                   },
                 ),

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -10,6 +10,7 @@ import 'package:mediavore/core/domain/entities/media_details.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
 import 'package:mediavore/features/media_details/data/datasources/media_list_local_data_source.dart';
 import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
 import 'package:mediavore/features/search/data/datasources/media_remote_data_source.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 
@@ -26,8 +27,15 @@ class MediaRepositoryImpl implements MediaRepository {
     required this.remoteDataSource,
     required this.localDataSource,
     required this.cache,
+    bool autoInit = true,
   }) {
-    _init();
+    if (autoInit) {
+      _init();
+    } else {
+      if (!_initCompleter.isCompleted) {
+        _initCompleter.complete();
+      }
+    }
   }
 
   Future<void> _init() async {
@@ -540,6 +548,128 @@ class MediaRepositoryImpl implements MediaRepository {
 
     // Trigger update of notification date when progress changes
     unawaited(_refreshNotificationDateByTmdbId(item.tmdbId, item.type));
+
+    // After marking as seen, for TV items compute next unseen episode for THIS streak
+    try {
+      if (item.type == MediaType.tv &&
+          item.seasonNumber != null &&
+          item.episodeNumber != null) {
+        // remove any quick-add that referred to the episode we just marked as seen
+        try {
+          await localDataSource.removeQuickAddItemByTmdbSeasonEpisode(
+            item.tmdbId,
+            seasonNumber: item.seasonNumber,
+            episodeNumber: item.episodeNumber,
+          );
+        } catch (_) {}
+
+        // compute next unseen episode starting after the one just marked
+        final seen = await localDataSource.getSeenStatus(item.tmdbId, 'tv');
+
+        MediaItem? detailsItem = cache.getItem(item.tmdbId, MediaType.tv);
+        if (detailsItem == null) {
+          try {
+            detailsItem = await remoteDataSource.getMediaItem(
+              item.tmdbId,
+              type: MediaType.tv,
+            );
+            await cache.cacheItem(detailsItem);
+          } catch (_) {
+            detailsItem = null;
+          }
+        }
+
+        if (detailsItem?.seasons != null) {
+          // Build map of last seen timestamp per episode so we can determine
+          // if an episode was seen after the one we just marked (chronological).
+          final Map<int, Map<int, DateTime>> lastSeenMap = {};
+          for (final s in seen) {
+            if (s.seasonNumber == null || s.episodeNumber == null) continue;
+            final season = s.seasonNumber!;
+            final ep = s.episodeNumber!;
+            final mapForSeason = lastSeenMap.putIfAbsent(season, () => {});
+            final prevSeen = mapForSeason[ep];
+            mapForSeason[ep] = (prevSeen == null || prevSeen.isBefore(s.seenDate)) ? s.seenDate : prevSeen;
+          }
+
+          final sortedSeasons = List<TVSeason>.from(detailsItem!.seasons!)
+            ..sort((a, b) => a.seasonNumber.compareTo(b.seasonNumber));
+
+          final startSeason = item.seasonNumber!;
+          final startEpisode = item.episodeNumber! + 1;
+          DateTime? foundAirDate;
+          int? foundSeason;
+          int? foundEpisode;
+
+          for (final season in sortedSeasons) {
+            if (season.seasonNumber == 0) continue;
+            if (season.seasonNumber < startSeason) continue;
+
+            try {
+              final seasonDetails = await getSeasonDetails(
+                detailsItem.id,
+                season.seasonNumber,
+              );
+              final episodes = seasonDetails['episodes'] as List?;
+              for (final ep in episodes ?? []) {
+                final epNum = ep['episode_number'] as int;
+
+                if (season.seasonNumber == startSeason && epNum < startEpisode) {
+                  continue;
+                }
+
+                final lastSeenForEp = lastSeenMap[season.seasonNumber]?[epNum];
+                final isEpSeenAfterMark =
+                  lastSeenForEp != null &&
+                  // Treat equal timestamps as "after" for tail grouping
+                  !lastSeenForEp.isBefore(item.seenDate);
+                if (isEpSeenAfterMark) {
+                  continue;
+                }
+
+                final airDateStr = ep['air_date'] as String?;
+                if (airDateStr != null) {
+                  try {
+                    final ad = DateTime.parse(airDateStr);
+                    if (ad.isAfter(DateTime.now())) {
+                      continue;
+                    }
+                    foundAirDate = ad;
+                  } catch (_) {}
+                }
+
+                foundSeason = season.seasonNumber;
+                foundEpisode = epNum;
+                break;
+              }
+            } catch (_) {}
+            if (foundSeason != null) break;
+          }
+
+          if (foundSeason != null && foundEpisode != null) {
+            // Respect per-streak opt-out for the streak identified by the episode we just marked
+            final optedOut = await localDataSource.isOptedOut(
+              item.tmdbId,
+              seasonNumber: item.seasonNumber,
+              episodeNumber: item.episodeNumber,
+            );
+            if (!optedOut) {
+              final quick = QuickAddItemModel(
+                tmdbId: item.tmdbId,
+                type: 'tv',
+                seasonNumber: foundSeason,
+                episodeNumber: foundEpisode,
+                insertedAt: item.seenDate,
+                airDate: foundAirDate,
+                title: detailsItem.title,
+                posterPath: detailsItem.posterPath,
+              );
+              await localDataSource.addQuickAddItem(quick);
+            }
+          }
+        }
+      }
+    } catch (_) {}
   }
 
   Future<void> _refreshNotificationDateByTmdbId(
@@ -889,6 +1019,34 @@ class MediaRepositoryImpl implements MediaRepository {
   }
 
   @override
+  Future<void> optOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await _ensureInitialized();
+    return localDataSource.addOptOut(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+  }
+
+  @override
+  Future<void> clearOptOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await _ensureInitialized();
+    return localDataSource.removeOptOut(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+  }
+
+  @override
   Future<void> refreshNotifiedItems() async {
     await _ensureInitialized();
     final notifiedItems = await localDataSource.getNotifiedItems();
@@ -956,5 +1114,244 @@ class MediaRepositoryImpl implements MediaRepository {
       debugPrint('[Repo] getVideos error: $e');
       return [];
     }
+  }
+
+  @override
+  Future<List<QuickAddItem>> getQuickAddItems() async {
+    await _ensureInitialized();
+    final items = await localDataSource.getQuickAddItems();
+    return items
+        .map(
+          (m) => QuickAddItem(
+            isarId: m.isarId,
+            tmdbId: m.tmdbId,
+            type: m.type == 'movie' ? MediaType.movie : MediaType.tv,
+            seasonNumber: m.seasonNumber,
+            episodeNumber: m.episodeNumber,
+            insertedAt: m.insertedAt,
+            airDate: m.airDate,
+            title: m.title,
+            posterPath: m.posterPath,
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<void> addQuickAddItem(QuickAddItem item) async {
+    await _ensureInitialized();
+    final model = QuickAddItemModel(
+      tmdbId: item.tmdbId,
+      type: item.type == MediaType.movie ? 'movie' : 'tv',
+      seasonNumber: item.seasonNumber,
+      episodeNumber: item.episodeNumber,
+      insertedAt: item.insertedAt,
+      airDate: item.airDate,
+      title: item.title,
+      posterPath: item.posterPath,
+    );
+    return localDataSource.addQuickAddItem(model);
+  }
+
+  @override
+  Future<void> removeQuickAddItemById(int isarId) async {
+    await _ensureInitialized();
+    return localDataSource.removeQuickAddItemById(isarId);
+  }
+
+  @override
+  Future<void> populateQuickAddFromSeenHistory({
+    int? tmdbId,
+    int? tailSeason,
+    int? tailEpisode,
+  }) async {
+    await _ensureInitialized();
+    try {
+      final seenItems = await localDataSource.getAllSeenItems();
+      var tvIds = seenItems
+          .where((s) => s.type == 'tv')
+          .map((s) => s.tmdbId)
+          .toSet();
+
+      // If caller requested a specific tmdbId, restrict to it (if present in seen)
+      if (tmdbId != null) {
+        if (tvIds.contains(tmdbId)) {
+          tvIds = {tmdbId};
+        } else {
+          // nothing to do
+          return;
+        }
+      }
+
+      final existingQuick = await localDataSource.getQuickAddItems();
+
+      for (final tmdbId in tvIds) {
+        final seen = await localDataSource.getSeenStatus(tmdbId, 'tv');
+
+        MediaItem? detailsItem = cache.getItem(tmdbId, MediaType.tv);
+        if (detailsItem == null) {
+          try {
+            detailsItem = await remoteDataSource.getMediaItem(
+              tmdbId,
+              type: MediaType.tv,
+            );
+            await cache.cacheItem(detailsItem);
+          } catch (_) {
+            detailsItem = null;
+          }
+        }
+
+        if (detailsItem?.seasons != null) {
+          // Build a map of the latest seen date per episode for quick timestamped lookup
+          final Map<int, Map<int, DateTime>> lastSeenMap = {};
+          for (final s in seen) {
+            if (s.seasonNumber == null || s.episodeNumber == null) continue;
+            final season = s.seasonNumber!;
+            final ep = s.episodeNumber!;
+            final mapForSeason = lastSeenMap.putIfAbsent(season, () => {});
+            final prevSeen = mapForSeason[ep];
+            mapForSeason[ep] = (prevSeen == null || prevSeen.isBefore(s.seenDate)) ? s.seenDate : prevSeen;
+          }
+
+          // Existing quick-add candidates for this tmdbId
+          final existingForId = existingQuick
+              .where((q) => q.tmdbId == tmdbId)
+              .map((q) => '${q.seasonNumber}:${q.episodeNumber}')
+              .toSet();
+
+          final sortedSeasons = List<TVSeason>.from(detailsItem!.seasons!)
+            ..sort((a, b) => a.seasonNumber.compareTo(b.seasonNumber));
+
+          // For each seen episode (treated as a tail candidate), compute the next episode
+          // that has NOT been seen after that seenDate. This respects chronological
+          // order: if the successor was seen earlier but not after this seenDate, it
+          // still counts as unseen for this tail.
+          final Set<String> addedKeysForId = {};
+          // iterate seen in reverse chronological order so most recent tails win for insertedAt
+          final seenSorted = List.from(seen)
+            ..sort((a, b) {
+              final dateCmp = b.seenDate.compareTo(a.seenDate);
+              if (dateCmp != 0) return dateCmp;
+              // If seenDate is equal, order by season (ascending) then episode (ascending)
+              final aSeason = a.seasonNumber ?? 0;
+              final bSeason = b.seasonNumber ?? 0;
+              if (aSeason != bSeason) return aSeason.compareTo(bSeason);
+              final aEp = a.episodeNumber ?? 0;
+              final bEp = b.episodeNumber ?? 0;
+              return aEp.compareTo(bEp);
+            });
+          for (final s in seenSorted) {
+            if (s.seasonNumber == null || s.episodeNumber == null) {
+              continue;
+            }
+            // If caller requested a specific tail, skip other seen entries
+            if (tailSeason != null && tailEpisode != null) {
+              if (s.seasonNumber != tailSeason ||
+                  s.episodeNumber != tailEpisode) {
+                continue;
+              }
+            }
+            final localTailSeason = s.seasonNumber!;
+            final localTailEpisode = s.episodeNumber!;
+            final tailSeenDate = s.seenDate;
+
+            int startSeason = localTailSeason;
+            int startEpisode = localTailEpisode + 1;
+
+            DateTime? foundAirDate;
+            int? foundSeason;
+            int? foundEpisode;
+
+            for (final season in sortedSeasons) {
+              if (season.seasonNumber == 0) {
+                continue;
+              }
+              if (season.seasonNumber < startSeason) {
+                continue;
+              }
+
+              try {
+                final seasonDetails = await getSeasonDetails(
+                  detailsItem.id,
+                  season.seasonNumber,
+                );
+                final episodes = seasonDetails['episodes'] as List?;
+                for (final ep in episodes ?? []) {
+                  final epNum = ep['episode_number'] as int;
+
+                  if (season.seasonNumber == startSeason &&
+                      epNum < startEpisode) {
+                    continue;
+                  }
+
+                  // Consider episode as "seen after tail" only if its last seen date
+                  // is strictly after the tail's seenDate.
+                    final lastSeenForEp = lastSeenMap[season.seasonNumber]?[epNum];
+                    final isEpSeenAfterTail =
+                      lastSeenForEp != null &&
+                      // Treat equal timestamps as "after" for tail grouping
+                      !lastSeenForEp.isBefore(tailSeenDate);
+                  if (isEpSeenAfterTail) {
+                    continue;
+                  }
+
+                  final airDateStr = ep['air_date'] as String?;
+                  if (airDateStr != null) {
+                    try {
+                      final ad = DateTime.parse(airDateStr);
+                      if (ad.isAfter(DateTime.now())) {
+                        // skip future episodes
+                        continue;
+                      }
+                      foundAirDate = ad;
+                    } catch (_) {}
+                  }
+
+                  foundSeason = season.seasonNumber;
+                  foundEpisode = epNum;
+                  break;
+                }
+              } catch (_) {}
+              if (foundSeason != null) break;
+            }
+
+            if (foundSeason != null && foundEpisode != null) {
+              final key = '$foundSeason:$foundEpisode';
+              if (existingForId.contains(key) || addedKeysForId.contains(key)) {
+                continue;
+              }
+
+              final optedOut = await localDataSource.isOptedOut(
+                tmdbId,
+                seasonNumber: localTailSeason,
+                episodeNumber: localTailEpisode,
+              );
+              if (optedOut) {
+                continue;
+              }
+
+              final quick = QuickAddItemModel(
+                tmdbId: tmdbId,
+                type: 'tv',
+                seasonNumber: foundSeason,
+                episodeNumber: foundEpisode,
+                insertedAt: tailSeenDate,
+                airDate: foundAirDate,
+                title: detailsItem.title,
+                posterPath: detailsItem.posterPath,
+              );
+              await localDataSource.addQuickAddItem(quick);
+              addedKeysForId.add(key);
+            }
+          }
+        }
+      }
+    } catch (_) {}
+  }
+
+  @override
+  Future<void> clearQuickAddItems() async {
+    await _ensureInitialized();
+    return localDataSource.clearQuickAddItems();
   }
 }

--- a/lib/features/search/domain/repositories/media_repository.dart
+++ b/lib/features/search/domain/repositories/media_repository.dart
@@ -165,6 +165,44 @@ abstract class MediaRepository {
 
   /// Gets videos (trailers, etc.) for a media item.
   Future<List<Map<String, dynamic>>> getVideos(int id, MediaType type);
+
+  /// QuickAdd: returns current quick-add entries (next episodes the user can quickly mark seen)
+  Future<List<QuickAddItem>> getQuickAddItems();
+
+  /// Removes a quick-add entry by its isar id.
+  Future<void> removeQuickAddItemById(int isarId);
+
+  /// User opts out of automatic quick-add for a specific streak.
+  /// If `seasonNumber`/`episodeNumber` are omitted, behavior defaults to opt-out for the series.
+  Future<void> optOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  });
+
+  /// Clears opt-out for a specific streak so quick-add resumes.
+  Future<void> clearOptOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  });
+
+  /// Populate quick-add collection from existing seen history.
+  /// If [tmdbId] is provided, only compute quick-add for that show.
+  /// If [tailSeason]/[tailEpisode] are provided, only compute for that specific tail.
+  /// This will compute next unseen episodes for TV shows (that have aired)
+  /// and persist quick-add entries where appropriate.
+  Future<void> populateQuickAddFromSeenHistory({
+    int? tmdbId,
+    int? tailSeason,
+    int? tailEpisode,
+  });
+
+  /// Clear all entries from the Quick Add collection.
+  Future<void> clearQuickAddItems();
+
+  /// Add a specific quick-add entry directly (used for Undo of a dismiss).
+  Future<void> addQuickAddItem(QuickAddItem item);
 }
 
 class NotifiedItem {
@@ -200,5 +238,29 @@ class MediaItemPreview {
     required this.title,
     this.posterPath,
     required this.type,
+  });
+}
+
+class QuickAddItem {
+  final int? isarId;
+  final int tmdbId;
+  final MediaType type;
+  final int? seasonNumber;
+  final int? episodeNumber;
+  final DateTime insertedAt;
+  final DateTime? airDate;
+  final String? title;
+  final String? posterPath;
+
+  QuickAddItem({
+    this.isarId,
+    required this.tmdbId,
+    required this.type,
+    this.seasonNumber,
+    this.episodeNumber,
+    required this.insertedAt,
+    this.airDate,
+    this.title,
+    this.posterPath,
   });
 }

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -47,6 +47,7 @@ class SearchProvider with ChangeNotifier {
   List<String> _watchlistIds = []; // Simplified IDs for quick checks
   List<String> _likedIds = []; // "id:type"
   List<NotifiedItem> _notifiedItems = [];
+  List<QuickAddItem> _quickAddItems = [];
 
   List<MediaItem> get items => _searchResults; // For SearchPage
   bool get isLoading => _isLoading;
@@ -64,6 +65,7 @@ class SearchProvider with ChangeNotifier {
   List<SeenItem> get seenItems => _seenItems;
   List<String> get likedIds => _likedIds;
   List<NotifiedItem> get notifiedItems => _notifiedItems;
+  List<QuickAddItem> get quickAddItems => _quickAddItems;
   int get selectedTab => _selectedTab;
 
   double get importProgress => _importProgress;
@@ -119,6 +121,7 @@ class SearchProvider with ChangeNotifier {
     await loadWatchlist();
     await loadLikedStatus();
     await loadNotifiedItems();
+    await loadQuickAddItems();
   }
 
   void setSelectedTab(int index) {
@@ -213,11 +216,24 @@ class SearchProvider with ChangeNotifier {
 
     _seenCounts = counts;
     notifyListeners();
+    await loadQuickAddItems();
   }
 
   Future<void> loadNotifiedItems() async {
     _notifiedItems = await repository.getNotifiedItems();
     notifyListeners();
+  }
+
+  Future<void> loadQuickAddItems() async {
+    final repoItems = await repository.getQuickAddItems();
+    // Use repository-provided quick-add entries only (no compatibility fallback)
+    _quickAddItems = repoItems;
+    notifyListeners();
+  }
+
+  Future<void> clearQuickAddItems() async {
+    await repository.clearQuickAddItems();
+    await loadQuickAddItems();
   }
 
   int getSeenCount(MediaItem item) {
@@ -641,6 +657,7 @@ class SearchProvider with ChangeNotifier {
     await loadAllSeenStatus();
     await loadNotifiedItems();
     await updateSeenDbSize();
+    await loadQuickAddItems();
   }
 
   Future<void> removeFromSeen(
@@ -658,6 +675,7 @@ class SearchProvider with ChangeNotifier {
     await loadAllSeenStatus();
     await loadNotifiedItems();
     await updateSeenDbSize();
+    await loadQuickAddItems();
   }
 
   List<MediaItemPreview> getPreviewsForList(String name) {
@@ -726,9 +744,58 @@ class SearchProvider with ChangeNotifier {
       await updateCacheSize();
       await updateSeenDbSize();
 
+      // After importing seen history, populate quick-add based on the new data
+      try {
+        await repository.populateQuickAddFromSeenHistory();
+      } catch (_) {}
+
       _isImporting = false;
       notifyListeners();
     }
+  }
+
+  Future<void> optOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await repository.optOutSeries(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+    await loadQuickAddItems();
+  }
+
+  Future<void> clearOptOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await repository.clearOptOutSeries(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+    await loadQuickAddItems();
+  }
+
+  Future<void> populateQuickAddFromSeenHistory({
+    int? tmdbId,
+    int? tailSeason,
+    int? tailEpisode,
+  }) async {
+    await repository.populateQuickAddFromSeenHistory(
+      tmdbId: tmdbId,
+      tailSeason: tailSeason,
+      tailEpisode: tailEpisode,
+    );
+    await loadQuickAddItems();
+  }
+
+  Future<void> addQuickAddItem(QuickAddItem item) async {
+    await repository.addQuickAddItem(item);
+    await loadQuickAddItems();
   }
 
   Future<({int seasonNumber, int episodeNumber})?> getNextEpisode(

--- a/lib/features/settings/presentation/pages/data_cache_settings_page.dart
+++ b/lib/features/settings/presentation/pages/data_cache_settings_page.dart
@@ -138,6 +138,33 @@ class DataCacheSettingsPage extends StatelessWidget {
                 ),
                 onTap: () => _importSeenData(context, provider),
               ),
+              ListTile(
+                leading: const Icon(Icons.playlist_add),
+                title: const Text('Populate Quick Add from Seen History'),
+                subtitle: const Text(
+                  'Compute next episodes from your seen history and save them to Quick Add.',
+                ),
+                enabled: !isImporting,
+                onTap: () => _confirmAction(
+                  context,
+                  title: 'Populate Quick Add',
+                  message:
+                      'This will compute next unseen episodes for your TV shows and add them to Quick Add. Proceed?',
+                  action: () async {
+                    // Clear existing quick-add entries so the populate action
+                    // fully reflects current seen history.
+                    await provider.clearQuickAddItems();
+                    await provider.populateQuickAddFromSeenHistory();
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(
+                          content: Text('Quick Add populated from history.'),
+                        ),
+                      );
+                    }
+                  },
+                ),
+              ),
               const Divider(),
               const _SectionHeader(title: 'Achievement Data'),
               ListTile(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -21,6 +21,9 @@ Future<void> main() async {
       debugPrint('Warning: .env file not found or failed to load: $e');
     }
 
+    // DefinitionsLoader should be provided by generated DI (injection.config.dart).
+    // Avoid manual registration here; run codegen to ensure it's registered.
+
     await init(locator);
     runApp(const MediaVoreApp());
   } catch (e, stackTrace) {

--- a/test/features/achievements/data/repositories/achievement_repository_impl_test.dart
+++ b/test/features/achievements/data/repositories/achievement_repository_impl_test.dart
@@ -6,7 +6,16 @@ import 'package:mediavore/features/media_details/data/models/seen_item_model.dar
 import 'package:mocktail/mocktail.dart';
 import 'dart:convert';
 import 'dart:io';
+import 'package:mediavore/core/di/definitions_loader.dart';
 import '../../../../helpers/mocks.dart';
+
+// Simple test helper that implements the runtime `DefinitionsLoader`.
+class _TestDefinitionsLoader implements DefinitionsLoader {
+  final Future<List<Map<String, dynamic>>> Function() _loader;
+  _TestDefinitionsLoader(this._loader);
+  @override
+  Future<List<Map<String, dynamic>>> load() => _loader();
+}
 
 void main() {
   late AchievementRepositoryImpl repository;
@@ -38,7 +47,11 @@ void main() {
       return list.map((e) => Map<String, dynamic>.from(e as Map)).toList();
     };
 
-    repository = AchievementRepositoryImpl(isar, mockDataSource, definitionsLoader: loader);
+    repository = AchievementRepositoryImpl(
+      isar,
+      mockDataSource,
+      definitionsLoader: _TestDefinitionsLoader(loader),
+    );
   });
 
   tearDown(() async {
@@ -112,7 +125,7 @@ void main() {
       final repoWithLoader = AchievementRepositoryImpl(
         isar,
         mockDataSource,
-        definitionsLoader: loader,
+        definitionsLoader: _TestDefinitionsLoader(loader),
       );
 
       // No seen items required for existence check — call getAchievements()

--- a/test/features/media_details/presentation/pages/mark_as_seen_entry_points_test.dart
+++ b/test/features/media_details/presentation/pages/mark_as_seen_entry_points_test.dart
@@ -290,7 +290,24 @@ void main() {
 
       // We need to build the QuickAddTab which is private; reuse the _QuickAddTab via NotificationCenterPage's _QuickAddTab
       // Refresh provider state so QuickAddTab sees the seen items
+      // Ensure repository returns a QuickAdd entry so the QuickAdd tab renders
+      when(() => mockRepository.getQuickAddItems()).thenAnswer((_) async => [
+            QuickAddItem(
+              isarId: null,
+              tmdbId: 30,
+              type: MediaType.tv,
+              seasonNumber: 1,
+              episodeNumber: 2,
+              insertedAt: DateTime.now(),
+              airDate: DateTime.now().subtract(const Duration(days: 1)),
+              title: 'Series30',
+              posterPath: null,
+            )
+          ]);
+
       await provider.loadAllSeenStatus();
+      // Ensure quick-add items are loaded from repository stub
+      await provider.loadQuickAddItems();
       await provider.loadWatchlist();
       await provider.loadNotifiedItems();
 

--- a/test/features/media_details/presentation/quickadd_undo_integration_test.dart
+++ b/test/features/media_details/presentation/quickadd_undo_integration_test.dart
@@ -1,0 +1,162 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:mediavore/features/media_details/data/datasources/media_list_local_data_source.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_opt_out_model.dart';
+
+/// Minimal test-only repo that delegates to the local datasource.
+class LocalTestRepo {
+  final MediaListLocalDataSource local;
+
+  LocalTestRepo(this.local);
+
+  Future<void> optOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await local.addOptOut(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+    await local.removeQuickAddItemByTmdbSeasonEpisode(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+  }
+
+  Future<void> clearOptOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) async {
+    await local.removeOptOut(
+      tmdbId,
+      seasonNumber: seasonNumber,
+      episodeNumber: episodeNumber,
+    );
+  }
+
+  Future<void> populateQuickAddFromSeenHistory() async {
+    // For this integration test, simply re-add a known quick-add if missing.
+    final existing = await local.getQuickAddItems();
+    final exists = existing.any(
+      (e) => e.tmdbId == 100 && e.seasonNumber == 1 && e.episodeNumber == 2,
+    );
+    if (!exists) {
+      await local.addQuickAddItem(
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 2,
+          insertedAt: DateTime.now(),
+          title: 'Test Show',
+        ),
+      );
+    }
+  }
+
+  Future<void> removeQuickAddItemById(int isarId) async =>
+      local.removeQuickAddItemById(isarId);
+}
+
+void main() {
+  late Isar isar;
+  late MediaListLocalDataSource local;
+  late LocalTestRepo repo;
+  late String tempPath;
+
+  setUp(() async {
+    // Avoid downloading native libs during CI/dev runs; change to 'true' if running on a clean machine.
+    try {
+      await Isar.initializeIsarCore(download: false);
+    } catch (_) {}
+
+    tempPath =
+        '${Directory.current.path}/test/tmp_quickadd_integration_${DateTime.now().microsecondsSinceEpoch}';
+    Directory(tempPath).createSync(recursive: true);
+
+    isar = await Isar.open(
+      [QuickAddItemModelSchema, QuickAddOptOutModelSchema],
+      directory: tempPath,
+      name: 'test_quickadd_db',
+    );
+
+    local = MediaListLocalDataSource(isar);
+    repo = LocalTestRepo(local);
+  });
+
+  tearDown(() async {
+    try {
+      await isar.close(deleteFromDisk: true);
+    } catch (_) {}
+    try {
+      if (Directory(tempPath).existsSync()) {
+        Directory(tempPath).deleteSync(recursive: true);
+      }
+    } catch (_) {}
+  });
+
+  test('isar quick-add opt-out and undo (non-widget)', () async {
+    final qaModel = QuickAddItemModel(
+      tmdbId: 100,
+      type: 'tv',
+      seasonNumber: 1,
+      episodeNumber: 2,
+      insertedAt: DateTime.now(),
+      title: 'Test Show',
+    );
+
+    // Add quick-add
+    await local.addQuickAddItem(qaModel).timeout(const Duration(seconds: 30));
+
+    // Simulate opt-out via repo
+    await repo
+        .optOutSeries(100, seasonNumber: 1, episodeNumber: 2)
+        .timeout(const Duration(seconds: 30));
+
+    // Verify removal
+    final remaining = await local.getQuickAddItems().timeout(
+      const Duration(seconds: 10),
+    );
+    expect(remaining.where((e) => e.tmdbId == 100).isEmpty, isTrue);
+
+    // Verify opt-out persisted
+    final opted = await local
+        .isOptedOut(100, seasonNumber: 1, episodeNumber: 2)
+        .timeout(const Duration(seconds: 10));
+    expect(opted, isTrue);
+
+    // Clear opt-out and repopulate
+    await repo
+        .clearOptOutSeries(100, seasonNumber: 1, episodeNumber: 2)
+        .timeout(const Duration(seconds: 10));
+    await repo.populateQuickAddFromSeenHistory().timeout(
+      const Duration(seconds: 30),
+    );
+
+    // Check restored
+    final restored = await local.getQuickAddItems().timeout(
+      const Duration(seconds: 10),
+    );
+    expect(
+      restored
+          .where(
+            (e) =>
+                e.tmdbId == 100 && e.seasonNumber == 1 && e.episodeNumber == 2,
+          )
+          .isNotEmpty,
+      isTrue,
+    );
+
+    final stillOpted = await local
+        .isOptedOut(100, seasonNumber: 1, episodeNumber: 2)
+        .timeout(const Duration(seconds: 10));
+    expect(stillOpted, isFalse);
+  });
+}

--- a/test/features/media_details/presentation/quickadd_undo_test.dart
+++ b/test/features/media_details/presentation/quickadd_undo_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:provider/provider.dart';
+import 'package:mediavore/features/media_details/presentation/pages/notification_center_page.dart';
+import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+import '../../../helpers/mocks.dart';
+import 'package:mediavore/core/domain/entities/seen_item.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+void main() {
+  late MockMediaRepository repo;
+  late SearchProvider provider;
+
+  setUpAll(() {
+    registerFallbackValue(FakeMediaItem());
+    registerFallbackValue(FakeQuickAddItem());
+  });
+
+  setUp(() async {
+    repo = MockMediaRepository();
+
+    // Basic stubs for initialization calls
+    when(() => repo.getAllListNames()).thenAnswer((_) async => <String>[]);
+    when(() => repo.getListEntries(any())).thenAnswer((_) async => <String>[]);
+    when(
+      () => repo.getListPreviews(any(), limit: any(named: 'limit')),
+    ).thenAnswer((_) async => <MediaItemPreview>[]);
+    when(() => repo.getCacheSize()).thenAnswer((_) async => 0);
+    when(() => repo.getSeenDbSize()).thenAnswer((_) async => 0);
+    when(() => repo.getSeenItems()).thenAnswer((_) async => <SeenItem>[]);
+    when(() => repo.getWatchlistEntries()).thenAnswer((_) async => <String>[]);
+    when(() => repo.getLikedEntries()).thenAnswer((_) async => <String>[]);
+    when(
+      () => repo.getNotifiedItems(),
+    ).thenAnswer((_) async => <NotifiedItem>[]);
+
+    final qa = QuickAddItem(
+      isarId: 1,
+      tmdbId: 100,
+      type: MediaType.tv,
+      seasonNumber: 1,
+      episodeNumber: 2,
+      insertedAt: DateTime.now(),
+      title: 'Test Show',
+      posterPath: null,
+    );
+
+    when(() => repo.getQuickAddItems()).thenAnswer((_) async => [qa]);
+    when(
+      () => repo.optOutSeries(
+        any(),
+        seasonNumber: any(named: 'seasonNumber'),
+        episodeNumber: any(named: 'episodeNumber'),
+      ),
+    ).thenAnswer((inv) async {
+      // After opting out, repo should return no quick-adds for this test
+      when(
+        () => repo.getQuickAddItems(),
+      ).thenAnswer((_) async => <QuickAddItem>[]);
+    });
+
+    when(
+      () => repo.clearOptOutSeries(
+        any(),
+        seasonNumber: any(named: 'seasonNumber'),
+        episodeNumber: any(named: 'episodeNumber'),
+      ),
+    ).thenAnswer((inv) async {
+      // Do nothing here; the UI now calls populateQuickAddFromSeenHistory()
+      return Future.value();
+    });
+
+    when(
+      () => repo.addQuickAddItem(any()),
+    ).thenAnswer((inv) async {
+      // Simulate repopulation by restoring the quick-add item
+      when(() => repo.getQuickAddItems()).thenAnswer((_) async => [qa]);
+    });
+
+    provider = SearchProvider(repo);
+    await provider.loadQuickAddItems();
+  });
+
+  testWidgets('swipe opt-out shows undo and undo calls clearOptOutSeries', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChangeNotifierProvider<SearchProvider>.value(
+          value: provider,
+          child: const NotificationCenterPage(),
+        ),
+      ),
+    );
+
+    // let init finish
+    await tester.pumpAndSettle();
+
+    // Switch to Quick Add tab
+    await tester.tap(find.text('Quick Add'));
+    await tester.pumpAndSettle();
+
+    // Ensure quick-add item is present
+    expect(find.text('Test Show'), findsOneWidget);
+
+    // Swipe left to dismiss (opt-out)
+    await tester.drag(find.text('Test Show'), const Offset(-400, 0));
+    await tester.pumpAndSettle();
+
+    // SnackBar with Undo should appear
+    expect(find.text('Streak opted out of Quick Add'), findsOneWidget);
+    expect(find.text('Undo'), findsOneWidget);
+
+    // Tap Undo
+    await tester.tap(find.text('Undo'));
+    await tester.pumpAndSettle();
+    // Verify clearOptOutSeries and populateQuickAddFromSeenHistory were called
+    verify(
+      () => repo.clearOptOutSeries(100, seasonNumber: 1, episodeNumber: 2),
+    ).called(1);
+    verify(
+      () => repo.addQuickAddItem(any()),
+    ).called(1);
+  });
+}

--- a/test/features/search/data/repositories/populate_quickadd_multi_tail_test.dart
+++ b/test/features/search/data/repositories/populate_quickadd_multi_tail_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mediavore/features/search/data/repositories/media_repository_impl.dart';
+import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+import '../../../../helpers/mocks.dart';
+
+void main() {
+  late MockMediaListLocalDataSource local;
+  late MockMediaRemoteDataSource remote;
+  late MockMediaCache cache;
+  late MediaRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(SeenItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      title: 'f',
+      seenDate: DateTime.now(),
+    ));
+    registerFallbackValue(QuickAddItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      insertedAt: DateTime.now(),
+    ));
+    registerFallbackValue(FakeMediaItem());
+  });
+
+  setUp(() {
+    local = MockMediaListLocalDataSource();
+    remote = MockMediaRemoteDataSource();
+    cache = MockMediaCache();
+
+    repository = MediaRepositoryImpl(
+      remoteDataSource: remote,
+      localDataSource: local,
+      cache: cache,
+      autoInit: false,
+    );
+  });
+
+  test('populateQuickAddFromSeenHistory adds one quick-add per streak tail', () async {
+    final tmdbId = 100;
+
+    // Create seen entries representing two separate streaks:
+    // - Season 1 episodes 1,2,3 (tail: s1e3)
+    // - Season 2 episodes 1,2 (tail: s2e2)
+    final now = DateTime.now();
+    final seenItems = [
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 10)), seasonNumber: 1, episodeNumber: 1),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 9)), seasonNumber: 1, episodeNumber: 2),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 8)), seasonNumber: 1, episodeNumber: 3),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 7)), seasonNumber: 2, episodeNumber: 1),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 6)), seasonNumber: 2, episodeNumber: 2),
+    ];
+
+    when(() => local.getAllSeenItems()).thenAnswer((_) async => seenItems);
+    when(() => local.getQuickAddItems()).thenAnswer((_) async => <QuickAddItemModel>[]);
+    when(() => local.isOptedOut(any(), seasonNumber: any(named: 'seasonNumber'), episodeNumber: any(named: 'episodeNumber')))
+        .thenAnswer((_) async => false);
+    when(() => local.getSeenStatus(tmdbId, 'tv')).thenAnswer((_) async => seenItems);
+
+    // Remote: return a MediaItem with two seasons
+    final media = MediaItem(
+      id: tmdbId,
+      title: 'T',
+      overview: '',
+      releaseDate: '2020-01-01',
+      seasons: [
+        TVSeason(id: 1, seasonNumber: 1, episodeCount: 5),
+        TVSeason(id: 2, seasonNumber: 2, episodeCount: 10),
+      ],
+    );
+
+    when(() => cache.getItem(tmdbId, MediaType.tv)).thenReturn(null);
+    when(() => remote.getMediaItem(tmdbId, type: MediaType.tv)).thenAnswer((_) async => media);
+
+    // Stub cache methods used by the repository
+    when(() => cache.cacheItem(any())).thenAnswer((_) async {});
+    when(() => cache.isSeasonCached(any(), any())).thenReturn(false);
+    when(() => cache.cacheSeason(any(), any(), any())).thenAnswer((_) async {});
+    when(() => cache.getSeason(any(), any())).thenReturn(null);
+
+    // Season details: episodes with air_date in the past
+    List<Map<String, dynamic>> makeEpisodes(int count) => List.generate(count, (i) => {
+          'episode_number': i + 1,
+          'air_date': '2020-01-0${(i % 9) + 1}',
+        });
+
+    when(() => remote.getSeasonDetails(tmdbId, 1)).thenAnswer((_) async => {'episodes': makeEpisodes(5)});
+    when(() => remote.getSeasonDetails(tmdbId, 2)).thenAnswer((_) async => {'episodes': makeEpisodes(10)});
+
+    final added = <QuickAddItemModel>[];
+    when(() => local.addQuickAddItem(any())).thenAnswer((inv) async {
+      final arg = inv.positionalArguments[0] as QuickAddItemModel;
+      added.add(arg);
+    });
+
+    await repository.populateQuickAddFromSeenHistory();
+
+    // Expect two quick-adds: season1 episode4 and season2 episode3
+    expect(added.length, 2);
+    final keys = added.map((a) => '${a.seasonNumber}:${a.episodeNumber}').toSet();
+    expect(keys, contains('1:4'));
+    expect(keys, contains('2:3'));
+  });
+}

--- a/test/features/search/data/repositories/populate_quickadd_same_timestamp_test.dart
+++ b/test/features/search/data/repositories/populate_quickadd_same_timestamp_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mediavore/features/search/data/repositories/media_repository_impl.dart';
+import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+import '../../../../helpers/mocks.dart';
+
+void main() {
+  late MockMediaListLocalDataSource local;
+  late MockMediaRemoteDataSource remote;
+  late MockMediaCache cache;
+  late MediaRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(SeenItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      title: 'f',
+      seenDate: DateTime.now(),
+    ));
+    registerFallbackValue(QuickAddItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      insertedAt: DateTime.now(),
+    ));
+    registerFallbackValue(FakeMediaItem());
+  });
+
+  setUp(() {
+    local = MockMediaListLocalDataSource();
+    remote = MockMediaRemoteDataSource();
+    cache = MockMediaCache();
+
+    repository = MediaRepositoryImpl(
+      remoteDataSource: remote,
+      localDataSource: local,
+      cache: cache,
+      autoInit: false,
+    );
+  });
+
+  test('equal timestamps are grouped into a single tail', () async {
+    final tmdbId = 200;
+
+    final now = DateTime.now();
+    // episodes 1 and 2 seen earlier, episodes 3 and 4 seen at the exact same time
+    final seenItems = [
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 3)), seasonNumber: 1, episodeNumber: 1),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now.subtract(Duration(days: 2)), seasonNumber: 1, episodeNumber: 2),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now, seasonNumber: 1, episodeNumber: 3),
+      SeenItemModel(tmdbId: tmdbId, type: 'tv', title: 'T', seenDate: now, seasonNumber: 1, episodeNumber: 4),
+    ];
+
+    when(() => local.getAllSeenItems()).thenAnswer((_) async => seenItems);
+    when(() => local.getQuickAddItems()).thenAnswer((_) async => <QuickAddItemModel>[]);
+    when(() => local.isOptedOut(any(), seasonNumber: any(named: 'seasonNumber'), episodeNumber: any(named: 'episodeNumber')))
+        .thenAnswer((_) async => false);
+    when(() => local.getSeenStatus(tmdbId, 'tv')).thenAnswer((_) async => seenItems);
+
+    final media = MediaItem(
+      id: tmdbId,
+      title: 'T',
+      overview: '',
+      releaseDate: '2020-01-01',
+      seasons: [
+        TVSeason(id: 1, seasonNumber: 1, episodeCount: 10),
+      ],
+    );
+
+    when(() => cache.getItem(tmdbId, MediaType.tv)).thenReturn(null);
+    when(() => remote.getMediaItem(tmdbId, type: MediaType.tv)).thenAnswer((_) async => media);
+
+    when(() => cache.cacheItem(any())).thenAnswer((_) async {});
+    when(() => cache.isSeasonCached(any(), any())).thenReturn(false);
+    when(() => cache.cacheSeason(any(), any(), any())).thenAnswer((_) async {});
+    when(() => cache.getSeason(any(), any())).thenReturn(null);
+
+    List<Map<String, dynamic>> makeEpisodes(int count) => List.generate(count, (i) => {
+          'episode_number': i + 1,
+          'air_date': '2020-01-0${(i % 9) + 1}',
+        });
+
+    when(() => remote.getSeasonDetails(tmdbId, 1)).thenAnswer((_) async => {'episodes': makeEpisodes(10)});
+
+    final added = <QuickAddItemModel>[];
+    when(() => local.addQuickAddItem(any())).thenAnswer((inv) async {
+      final arg = inv.positionalArguments[0] as QuickAddItemModel;
+      added.add(arg);
+    });
+
+    await repository.populateQuickAddFromSeenHistory();
+
+    // Because episodes 3 and 4 share the exact same timestamp, they should be
+    // considered the same tail and only produce one quick-add (for episode 5).
+    expect(added.length, 1);
+    final a = added.first;
+    expect(a.seasonNumber, 1);
+    expect(a.episodeNumber, 5);
+  });
+}

--- a/test/features/search/presentation/providers/search_provider_test.dart
+++ b/test/features/search/presentation/providers/search_provider_test.dart
@@ -279,5 +279,41 @@ void main() {
         expect(provider.getSeenCount(tvItem), 1);
       },
     );
+
+    test('importSeenData triggers quick-add population', () async {
+      when(
+        () => mockRepository.importSeenData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(
+        () => mockRepository.populateQuickAddFromSeenHistory(),
+      ).thenAnswer((_) async {});
+
+      final seenData = [
+        {
+          'tmdbId': 1,
+          'type': 'tv',
+          'seasonNumber': 1,
+          'episodeNumber': 1,
+          'seenDate': DateTime(2020, 1, 1).toIso8601String(),
+        }
+      ];
+
+      await provider.importSeenData(seenData, mode: ImportMode.append);
+
+      verify(
+        () => mockRepository.importSeenData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).called(1);
+
+      verify(() => mockRepository.populateQuickAddFromSeenHistory()).called(1);
+    });
   });
 }

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -13,7 +13,109 @@ import 'package:mediavore/core/cache/media_cache.dart';
 
 class MockDio extends Mock implements Dio {}
 
-class MockMediaRepository extends Mock implements MediaRepository {}
+class MockMediaRepository extends Mock implements MediaRepository {
+  @override
+  Future<List<QuickAddItem>> getQuickAddItems() {
+    try {
+      return super.noSuchMethod(Invocation.method(#getQuickAddItems, []))
+          as Future<List<QuickAddItem>>;
+    } catch (_) {
+      return Future.value(<QuickAddItem>[]);
+    }
+  }
+
+  @override
+  Future<void> removeQuickAddItemById(int isarId) {
+    try {
+      return super.noSuchMethod(
+            Invocation.method(#removeQuickAddItemById, [isarId]),
+          )
+          as Future<void>;
+    } catch (_) {
+      return Future.value();
+    }
+  }
+
+  @override
+  Future<void> optOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) {
+    try {
+      return super.noSuchMethod(
+            Invocation.method(
+              #optOutSeries,
+              [tmdbId],
+              {#seasonNumber: seasonNumber, #episodeNumber: episodeNumber},
+            ),
+          )
+          as Future<void>;
+    } catch (_) {
+      return Future.value();
+    }
+  }
+
+  @override
+  Future<void> clearOptOutSeries(
+    int tmdbId, {
+    int? seasonNumber,
+    int? episodeNumber,
+  }) {
+    try {
+      return super.noSuchMethod(
+            Invocation.method(
+              #clearOptOutSeries,
+              [tmdbId],
+              {#seasonNumber: seasonNumber, #episodeNumber: episodeNumber},
+            ),
+          )
+          as Future<void>;
+    } catch (_) {
+      return Future.value();
+    }
+  }
+
+  @override
+  Future<void> populateQuickAddFromSeenHistory({
+    int? tmdbId,
+    int? tailSeason,
+    int? tailEpisode,
+  }) {
+    try {
+      return super.noSuchMethod(
+            Invocation.method(#populateQuickAddFromSeenHistory, [], {
+              #tmdbId: tmdbId,
+              #tailSeason: tailSeason,
+              #tailEpisode: tailEpisode,
+            }),
+          )
+          as Future<void>;
+    } catch (_) {
+      return Future.value();
+    }
+  }
+
+  @override
+  Future<void> importSeenData(
+    List<Map<String, dynamic>> data, {
+    ImportMode mode = ImportMode.append,
+    Function(double, String)? onProgress,
+  }) {
+    try {
+      return super.noSuchMethod(
+            Invocation.method(
+              #importSeenData,
+              [data],
+              {#mode: mode, #onProgress: onProgress},
+            ),
+          )
+          as Future<void>;
+    } catch (_) {
+      return Future.value();
+    }
+  }
+}
 
 class MockSharedPreferences extends Mock implements SharedPreferences {}
 
@@ -33,3 +135,5 @@ class MockAchievementProvider extends Mock implements AchievementProvider {}
 class FakeSeenItem extends Fake implements SeenItem {}
 
 class FakeMediaItem extends Fake implements MediaItem {}
+ 
+class FakeQuickAddItem extends Fake implements QuickAddItem {}


### PR DESCRIPTION
Closes #79 
Closes #103

- Added `QuickAddItemModel` and `QuickAddOptOutModel` Isar collections to persist "Next Episode" suggestions and user opt-outs.
- Implemented `populateQuickAddFromSeenHistory` in `MediaRepository` to automatically compute the next aired, unseen episode for every distinct viewing streak in the user's history.
- Refactored `NotificationCenterPage` to use the new persistent Quick Add system, replacing the previous on-the-fly computation.
- Added swipe-to-dismiss functionality in the Quick Add tab to allow users to opt out of specific streaks with an "Undo" option.
- Added a manual "Populate Quick Add from Seen History" action in Data & Cache settings.
- Integrated `DefinitionsLoader` interface to decouple achievement loading, improving testability.
- Added comprehensive unit and integration tests for streak grouping, timestamp handling, and opt-out/undo logic.