### PR TITLE
feat(media_details): add collection support and saga navigation

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -12,12 +12,12 @@ import 'package:dio/dio.dart' as _i5;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i6;
-import 'package:shared_preferences/shared_preferences.dart' as _i12;
+import 'package:shared_preferences/shared_preferences.dart' as _i10;
 
 import '../../features/achievements/data/repositories/achievement_repository_impl.dart'
-    as _i14;
+    as _i12;
 import '../../features/achievements/domain/repositories/achievement_repository.dart'
-    as _i13;
+    as _i11;
 import '../../features/achievements/presentation/providers/achievement_provider.dart'
     as _i15;
 import '../../features/media_details/data/datasources/media_list_local_data_source.dart'
@@ -25,9 +25,9 @@ import '../../features/media_details/data/datasources/media_list_local_data_sour
 import '../../features/search/data/datasources/media_remote_data_source.dart'
     as _i9;
 import '../../features/search/data/repositories/media_repository_impl.dart'
-    as _i11;
+    as _i14;
 import '../../features/search/domain/repositories/media_repository.dart'
-    as _i10;
+    as _i13;
 import '../cache/media_cache.dart' as _i7;
 import '../database/app_database.dart' as _i17;
 import 'asset_definitions_loader.dart' as _i4;
@@ -60,24 +60,26 @@ Future<_i1.GetIt> init(
         dio: gh<_i5.Dio>(),
         apiToken: gh<String>(),
       ));
-  gh.lazySingleton<_i10.MediaRepository>(() => _i11.MediaRepositoryImpl(
-        remoteDataSource: gh<_i9.MediaRemoteDataSource>(),
-        localDataSource: gh<_i8.MediaListLocalDataSource>(),
-        cache: gh<_i7.MediaCache>(),
-      ));
-  await gh.factoryAsync<_i12.SharedPreferences>(
+  await gh.factoryAsync<_i10.SharedPreferences>(
     () => registerModule.sharedPreferences,
     preResolve: true,
   );
   gh.singleton<String>(() => registerModule.apiToken);
-  gh.lazySingleton<_i13.AchievementRepository>(
-      () => _i14.AchievementRepositoryImpl(
+  gh.singleton<bool>(() => registerModule.autoInit);
+  gh.lazySingleton<_i11.AchievementRepository>(
+      () => _i12.AchievementRepositoryImpl(
             gh<_i6.Isar>(),
             gh<_i8.MediaListLocalDataSource>(),
             definitionsLoader: gh<_i3.DefinitionsLoader>(),
           ));
+  gh.lazySingleton<_i13.MediaRepository>(() => _i14.MediaRepositoryImpl(
+        remoteDataSource: gh<_i9.MediaRemoteDataSource>(),
+        localDataSource: gh<_i8.MediaListLocalDataSource>(),
+        cache: gh<_i7.MediaCache>(),
+        autoInit: gh<bool>(),
+      ));
   gh.lazySingleton<_i15.AchievementProvider>(
-      () => _i15.AchievementProvider(gh<_i13.AchievementRepository>()));
+      () => _i15.AchievementProvider(gh<_i11.AchievementRepository>()));
   return getIt;
 }
 

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -21,6 +21,9 @@ abstract class RegisterModule {
   @singleton
   String get apiToken => dotenv.env['TMDB_API_TOKEN'] ?? '';
 
+  @singleton
+  bool get autoInit => true;
+
   @preResolve
   Future<SharedPreferences> get sharedPreferences =>
       SharedPreferences.getInstance();

--- a/lib/core/domain/entities/media_details.dart
+++ b/lib/core/domain/entities/media_details.dart
@@ -8,6 +8,7 @@ class MediaDetails {
   final CrewMember? director;
   final List<MediaItem>? similar;
   final List<MediaItem>? recommendations;
+  final List<MediaItem>? collection;
   final Map<String, dynamic>? watchProviders;
   final List<Map<String, dynamic>>? videos;
 
@@ -16,6 +17,7 @@ class MediaDetails {
     required this.cast,
     this.director,
     this.similar,
+    this.collection,
     this.recommendations,
     this.watchProviders,
     this.videos,
@@ -27,6 +29,7 @@ class MediaDetails {
       'cast': cast.map((c) => c.toJson()).toList(),
       'director': director?.toJson(),
       'similar': similar?.map((i) => i.toJson()).toList(),
+      'collection': collection?.map((i) => i.toJson()).toList(),
       'recommendations': recommendations?.map((i) => i.toJson()).toList(),
       'watch_providers': watchProviders,
       'videos': videos,
@@ -47,6 +50,11 @@ class MediaDetails {
           ? (json['recommendations'] as List)
                 .map((i) => MediaItem.fromJson(i))
                 .toList()
+          : null,
+      collection: json['collection'] != null
+          ? (json['collection'] as List)
+            .map((i) => MediaItem.fromJson(i))
+            .toList()
           : null,
       watchProviders: json['watch_providers'],
       videos: json['videos'] != null

--- a/lib/core/domain/entities/media_item.dart
+++ b/lib/core/domain/entities/media_item.dart
@@ -57,6 +57,8 @@ class MediaItem extends Equatable {
   final String? lastEpisodeAirDate;
   final int? lastEpisodeNumber;
   final int? lastSeasonNumber;
+  final int? collectionId;
+  final String? collectionName;
 
   const MediaItem({
     required this.id,
@@ -78,6 +80,8 @@ class MediaItem extends Equatable {
     this.lastEpisodeAirDate,
     this.lastEpisodeNumber,
     this.lastSeasonNumber,
+    this.collectionId,
+    this.collectionName,
   });
 
   factory MediaItem.fromJson(Map<String, dynamic> json) {
@@ -147,6 +151,12 @@ class MediaItem extends Equatable {
       lastEpisodeAirDate: lastAirDate,
       lastEpisodeNumber: lastEpNum,
       lastSeasonNumber: lastSeasNum,
+      collectionId: json['belongs_to_collection'] is Map
+          ? (json['belongs_to_collection']['id'] as int?)
+          : null,
+      collectionName: json['belongs_to_collection'] is Map
+          ? (json['belongs_to_collection']['name'] as String?)
+          : null,
     );
   }
 
@@ -215,6 +225,8 @@ class MediaItem extends Equatable {
     String? lastEpisodeAirDate,
     int? lastEpisodeNumber,
     int? lastSeasonNumber,
+    int? collectionId,
+    String? collectionName,
   }) {
     return MediaItem(
       id: id ?? this.id,
@@ -236,6 +248,8 @@ class MediaItem extends Equatable {
       lastEpisodeAirDate: lastEpisodeAirDate ?? this.lastEpisodeAirDate,
       lastEpisodeNumber: lastEpisodeNumber ?? this.lastEpisodeNumber,
       lastSeasonNumber: lastSeasonNumber ?? this.lastSeasonNumber,
+      collectionId: collectionId ?? this.collectionId,
+      collectionName: collectionName ?? this.collectionName,
     );
   }
 
@@ -260,5 +274,7 @@ class MediaItem extends Equatable {
     lastEpisodeAirDate,
     lastEpisodeNumber,
     lastSeasonNumber,
+    collectionId,
+    collectionName,
   ];
 }

--- a/lib/core/utils/saga_sort.dart
+++ b/lib/core/utils/saga_sort.dart
@@ -1,0 +1,49 @@
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+/// Utilities to sort and rotate saga/collection elements.
+///
+/// Primary sort key:
+/// - For TV: `lastEpisodeAirDate` if available
+/// - For movies: `releaseDate`
+///
+/// Sorting is ascending by date (older -> newer).
+DateTime? _parseItemDate(MediaItem item) {
+  final src = item.mediaType == MediaType.tv
+      ? item.lastEpisodeAirDate
+      : item.releaseDate;
+  if (src == null || src.isEmpty) return null;
+  try {
+    return DateTime.tryParse(src);
+  } catch (_) {
+    return null;
+  }
+}
+
+List<MediaItem> sortSagaByDate(List<MediaItem> items) {
+  final copy = List<MediaItem>.from(items);
+  copy.sort((a, b) {
+    final da = _parseItemDate(a);
+    final db = _parseItemDate(b);
+    if (da == null && db == null) return 0;
+    if (da == null) return 1; // nulls go last
+    if (db == null) return -1;
+    return da.compareTo(db);
+  });
+  return copy;
+}
+
+/// Rotate a chronologically-sorted saga list so items after the `currentId`
+/// come first, then the preceding items. The current item is omitted from
+/// the returned list.
+///
+/// Example: sorted = [1,2,3,4,5], currentId=3 -> returns [4,5,1,2]
+List<MediaItem> rotateSagaElements(List<MediaItem> items, int currentId) {
+  if (items.isEmpty) return items;
+  final sorted = sortSagaByDate(items);
+  final index = sorted.indexWhere((i) => i.id == currentId);
+  if (index == -1) return sorted;
+
+  final after = index + 1 < sorted.length ? sorted.sublist(index + 1) : <MediaItem>[];
+  final before = sorted.sublist(0, index);
+  return [...after, ...before];
+}

--- a/lib/features/media_details/presentation/pages/media_detail_page.dart
+++ b/lib/features/media_details/presentation/pages/media_detail_page.dart
@@ -17,6 +17,7 @@ import 'package:mediavore/features/media_details/presentation/widgets/watch_next
 import 'package:mediavore/features/media_details/presentation/widgets/watchlist_icon_button.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:mediavore/core/utils/saga_sort.dart';
 import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:cached_network_image/cached_network_image.dart';
@@ -536,8 +537,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                               itemToDisplay.numberOfEpisodes != null)
                             _SearchIconText(
                               icon: Icons.subscriptions,
-                              text:
-                                  '${itemToDisplay.numberOfEpisodes} Episodes',
+                              text: '${itemToDisplay.numberOfEpisodes} Episodes',
                             ),
                         ],
                       ),
@@ -630,12 +630,8 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                                 subtitle: Text(
                                   '$episodesSeenInSeason / ${season.episodeCount} episodes seen',
                                   style: TextStyle(
-                                    color: isComplete
-                                        ? colors.onWatchlist
-                                        : null,
-                                    fontWeight: isComplete
-                                        ? FontWeight.bold
-                                        : null,
+                                    color: isComplete ? colors.onWatchlist : null,
+                                    fontWeight: isComplete ? FontWeight.bold : null,
                                   ),
                                 ),
                                 trailing: Row(
@@ -655,16 +651,13 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                                             ),
                                           )
                                         : Icon(
-                                            isExpanded
-                                                ? Icons.expand_less
-                                                : Icons.expand_more,
+                                            isExpanded ? Icons.expand_less : Icons.expand_more,
                                           ),
                                   ],
                                 ),
                                 onTap: () => _fetchSeasonDetails(seasonNumber),
                               ),
-                              if (isExpanded &&
-                                  _episodesBySeason.containsKey(seasonNumber))
+                              if (isExpanded && _episodesBySeason.containsKey(seasonNumber))
                                 Padding(
                                   padding: const EdgeInsets.only(left: 16.0),
                                   child: Column(
@@ -684,9 +677,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                                               ),
                                               item: itemToDisplay,
                                               seasonNumber: seasonNumber,
-                                              episodeNumber:
-                                                  episode['episode_number']
-                                                      as int,
+                                              episodeNumber: episode['episode_number'] as int,
                                             ),
                                           );
                                         })
@@ -778,6 +769,14 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                         ),
                       ),
 
+                      // Saga section goes first if available
+                      if (_mediaDetails!.collection != null &&
+                          _mediaDetails!.collection!.isNotEmpty)
+                        _buildSagaList(
+                          'Saga',
+                          _mediaDetails!.collection!,
+                          itemToDisplay.id,
+                        ),
                       _buildHorizontalList('Similar', _mediaDetails!.similar),
                       _buildHorizontalList(
                         'Recommendations',
@@ -933,6 +932,87 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
             itemCount: items.length,
             itemBuilder: (context, index) {
               final item = items[index];
+              return GestureDetector(
+                onTap: () {
+                  MediaDetailPage.show(context, item);
+                },
+                child: Container(
+                  width: 100,
+                  margin: const EdgeInsets.only(right: 12),
+                  child: Column(
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: item.posterPath != null
+                            ? CachedNetworkImage(
+                                imageUrl:
+                                    'https://image.tmdb.org/t/p/w185${item.posterPath}',
+                                height: 120,
+                                fit: BoxFit.cover,
+                                placeholder: (context, url) =>
+                                    Container(color: Colors.grey[200]),
+                                errorWidget: (context, url, error) => Icon(
+                                  item.mediaType == MediaType.tv
+                                      ? Icons.tv
+                                      : Icons.movie,
+                                ),
+                              )
+                            : Container(
+                                height: 120,
+                                color: Colors.grey[300],
+                                child: Icon(
+                                  item.mediaType == MediaType.tv
+                                      ? Icons.tv
+                                      : Icons.movie,
+                                ),
+                              ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        item.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(fontSize: 12),
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// Builds a saga/collection horizontal list.
+  ///
+  /// `items` are first sorted chronologically (movies by `releaseDate`,
+  /// TV by `lastEpisodeAirDate`) and then rotated so elements after
+  /// `currentId` appear first. The current item is omitted.
+  Widget _buildSagaList(String title, List<MediaItem>? items, int currentId) {
+    if (items == null || items.isEmpty) return const SizedBox.shrink();
+
+    final rotated = rotateSagaElements(items, currentId);
+
+    if (rotated.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 24),
+        Text(
+          title,
+          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        SizedBox(
+          height: 150,
+          child: ListView.builder(
+            scrollDirection: Axis.horizontal,
+            itemCount: rotated.length,
+            itemBuilder: (context, index) {
+              final item = rotated[index];
               return GestureDetector(
                 onTap: () {
                   MediaDetailPage.show(context, item);

--- a/lib/features/search/data/datasources/media_remote_data_source.dart
+++ b/lib/features/search/data/datasources/media_remote_data_source.dart
@@ -374,6 +374,24 @@ class MediaRemoteDataSource {
     }
   }
 
+  /// Fetches the parts of a collection (saga) by collection id.
+  Future<List<MediaItem>> getCollectionParts(int collectionId) async {
+    try {
+      final response = await dio.get(
+        'https://api.themoviedb.org/3/collection/$collectionId',
+        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+      );
+      final List results = response.data['parts'] ?? [];
+      return results.map((m) {
+        final data = Map<String, dynamic>.from(m);
+        if (data['media_type'] == null) data['media_type'] = 'movie';
+        return MediaItem.fromJson(data);
+      }).toList();
+    } catch (e) {
+      throw ParsingException('Failed to fetch collection parts', e);
+    }
+  }
+
   Future<List<MediaItem>> getRecommendedMedia(int id, MediaType type) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -246,12 +246,23 @@ class MediaRepositoryImpl implements MediaRepository {
     final Map<String, dynamic> watchProviders = await watchProvidersFuture;
     final List<Map<String, dynamic>> videos = await videosFuture;
 
+    // If this item belongs to a collection, fetch collection parts (saga)
+    List<MediaItem>? collectionParts;
+    if (item.collectionId != null) {
+      try {
+        collectionParts = await remoteDataSource.getCollectionParts(item.collectionId!);
+      } catch (_) {
+        collectionParts = null;
+      }
+    }
+
     final details = MediaDetails(
       item: item,
       cast: cast,
       director: director,
       similar: similar,
       recommendations: recommendations,
+      collection: collectionParts,
       watchProviders: watchProviders,
       videos: videos,
     );

--- a/test/core/utils/saga_sort_test.dart
+++ b/test/core/utils/saga_sort_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediavore/core/utils/saga_sort.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+void main() {
+  test('sortSagaByDate sorts movies by releaseDate and TV by lastEpisodeAirDate', () {
+    final m1 = MediaItem(id: 1, title: 'M1', overview: '', releaseDate: '2000-01-01');
+    final m2 = MediaItem(id: 2, title: 'M2', overview: '', releaseDate: '2005-01-01');
+    final tv3 = MediaItem(
+      id: 3,
+      title: 'TV3',
+      overview: '',
+      releaseDate: '2008-01-01',
+      mediaType: MediaType.tv,
+      lastEpisodeAirDate: '2010-06-01',
+    );
+
+    final list = [m2, tv3, m1];
+    final sorted = sortSagaByDate(list);
+    expect(sorted.map((i) => i.id).toList(), [1, 2, 3]);
+  });
+
+  test('rotateSagaElements rotates around current id and omits current', () {
+    final items = List.generate(
+      5,
+      (i) => MediaItem(id: i + 1, title: 'T${i + 1}', overview: '', releaseDate: '200${i + 1}-01-01'),
+    );
+
+    final rotated = rotateSagaElements(items, 3);
+    expect(rotated.map((i) => i.id).toList(), [4, 5, 1, 2]);
+  });
+
+  test('items with null/empty dates go last', () {
+    final withDate = MediaItem(id: 1, title: 'D', overview: '', releaseDate: '2020-01-01');
+    final noDate = MediaItem(id: 2, title: 'ND', overview: '', releaseDate: '');
+    final sorted = sortSagaByDate([noDate, withDate]);
+    expect(sorted.map((i) => i.id).toList(), [1, 2]);
+  });
+}


### PR DESCRIPTION
Closes #76

- Added `collectionId` and `collectionName` to `MediaItem` entity with JSON parsing support.
- Updated `MediaDetails` entity and `MediaRepositoryImpl` to fetch and store collection parts (sagas) from TMDB.
- Introduced `saga_sort.dart` utility to chronologically sort and rotate saga elements for better navigation flow.
- Implemented a "Saga" horizontal list in `MediaDetailPage` that displays related collection items.
- Added unit tests for saga sorting and rotation logic in `saga_sort_test.dart`.
- Minor UI polish and formatting in `MediaDetailPage`.