### PR TITLE
chore: update bundle identifier and add iOS privacy descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Content:
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      "package_name": "com.example.mediavore",
+      "package_name": "fr.zimberts.mediavore",
       "sha256_cert_fingerprints": [
         "YOUR_APP_SHA256_FINGERPRINT"
       ]

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.mediavore"
+    namespace = "fr.zimberts.mediavore"
     compileSdk = 36
     ndkVersion = flutter.ndkVersion
 
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.mediavore"
+        applicationId = "fr.zimberts.mediavore"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.mediavore">
+    package="fr.zimberts.mediavore">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="MediaVore"
@@ -13,7 +13,7 @@
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize"
-            android:name="com.example.mediavore.MainActivity">
+            android:name="fr.zimberts.mediavore.MainActivity">
             <meta-data
               android:name="io.flutter.embedding.android.NormalTheme"
               android:resource="@style/NormalTheme"

--- a/android/app/src/main/kotlin/fr/zimberts/mediavore/MainActivity.kt
+++ b/android/app/src/main/kotlin/fr/zimberts/mediavore/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.mediavore
+package fr.zimberts.mediavore
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -477,7 +477,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -494,7 +494,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -512,7 +512,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -528,7 +528,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -659,7 +659,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -681,7 +681,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -24,6 +24,12 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>MediaVore needs access to the camera to scan book/dvd barcodes.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>MediaVore needs access to the photo library to share or attach media.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>MediaVore needs permission to save images to your library.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,7 @@ project(runner LANGUAGES CXX)
 set(BINARY_NAME "mediavore")
 # The unique GTK application identifier for this application. See:
 # https://wiki.gnome.org/HowDoI/ChooseApplicationID
-set(APPLICATION_ID "com.example.mediavore")
+set(APPLICATION_ID "fr.zimberts.mediavore")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mediavore.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mediavore";
@@ -399,7 +399,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mediavore.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mediavore";
@@ -413,7 +413,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/mediavore.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/mediavore";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = mediavore
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.mediavore
+PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 fr.zimberts. All rights reserved.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "fr.zimberts" "\0"
             VALUE "FileDescription", "mediavore" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "mediavore" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 fr.zimberts. All rights reserved." "\0"
             VALUE "OriginalFilename", "mediavore.exe" "\0"
             VALUE "ProductName", "mediavore" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
Closes #112 

- Update organization prefix and bundle identifier from `com.example` to `fr.zimberts` across Android, iOS, macOS, Windows, and Linux configurations.
- Relocate Android `MainActivity.kt` to match the new package structure.
- Add `NSCameraUsageDescription`, `NSPhotoLibraryUsageDescription`, and `NSPhotoLibraryAddUsageDescription` to iOS `Info.plist` for barcode scanning and media sharing.
- Update application ID in `README.md` and build configuration files.
- Update copyright and company name metadata in desktop runner configurations.