### PR TITLE
feat(settings): migrate TMDB API key storage from environment variables to shared preferences

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -12,18 +12,18 @@ import 'package:dio/dio.dart' as _i5;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i6;
-import 'package:shared_preferences/shared_preferences.dart' as _i10;
+import 'package:shared_preferences/shared_preferences.dart' as _i9;
 
 import '../../features/achievements/data/repositories/achievement_repository_impl.dart'
-    as _i12;
-import '../../features/achievements/domain/repositories/achievement_repository.dart'
     as _i11;
+import '../../features/achievements/domain/repositories/achievement_repository.dart'
+    as _i10;
 import '../../features/achievements/presentation/providers/achievement_provider.dart'
     as _i15;
 import '../../features/media_details/data/datasources/media_list_local_data_source.dart'
     as _i8;
 import '../../features/search/data/datasources/media_remote_data_source.dart'
-    as _i9;
+    as _i12;
 import '../../features/search/data/repositories/media_repository_impl.dart'
     as _i14;
 import '../../features/search/domain/repositories/media_repository.dart'
@@ -56,30 +56,29 @@ Future<_i1.GetIt> init(
   gh.lazySingleton<_i7.MediaCache>(() => _i7.MediaCache(gh<_i6.Isar>()));
   gh.lazySingleton<_i8.MediaListLocalDataSource>(
       () => _i8.MediaListLocalDataSource(gh<_i6.Isar>()));
-  gh.lazySingleton<_i9.MediaRemoteDataSource>(() => _i9.MediaRemoteDataSource(
-        dio: gh<_i5.Dio>(),
-        apiToken: gh<String>(),
-      ));
-  await gh.factoryAsync<_i10.SharedPreferences>(
+  await gh.factoryAsync<_i9.SharedPreferences>(
     () => registerModule.sharedPreferences,
     preResolve: true,
   );
-  gh.singleton<String>(() => registerModule.apiToken);
   gh.singleton<bool>(() => registerModule.autoInit);
-  gh.lazySingleton<_i11.AchievementRepository>(
-      () => _i12.AchievementRepositoryImpl(
+  gh.lazySingleton<_i10.AchievementRepository>(
+      () => _i11.AchievementRepositoryImpl(
             gh<_i6.Isar>(),
             gh<_i8.MediaListLocalDataSource>(),
             definitionsLoader: gh<_i3.DefinitionsLoader>(),
           ));
+  gh.lazySingleton<_i12.MediaRemoteDataSource>(() => _i12.MediaRemoteDataSource(
+        dio: gh<_i5.Dio>(),
+        prefs: gh<_i9.SharedPreferences>(),
+      ));
   gh.lazySingleton<_i13.MediaRepository>(() => _i14.MediaRepositoryImpl(
-        remoteDataSource: gh<_i9.MediaRemoteDataSource>(),
+        remoteDataSource: gh<_i12.MediaRemoteDataSource>(),
         localDataSource: gh<_i8.MediaListLocalDataSource>(),
         cache: gh<_i7.MediaCache>(),
         autoInit: gh<bool>(),
       ));
   gh.lazySingleton<_i15.AchievementProvider>(
-      () => _i15.AchievementProvider(gh<_i11.AchievementRepository>()));
+      () => _i15.AchievementProvider(gh<_i10.AchievementRepository>()));
   return getIt;
 }
 

--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -17,10 +16,6 @@ void configureDependencies() {}
 abstract class RegisterModule {
   @singleton
   Dio get dio => Dio();
-
-  @singleton
-  String get apiToken => dotenv.env['TMDB_API_TOKEN'] ?? '';
-
   @singleton
   bool get autoInit => true;
 

--- a/lib/features/search/data/datasources/media_remote_data_source.dart
+++ b/lib/features/search/data/datasources/media_remote_data_source.dart
@@ -1,6 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:injectable/injectable.dart';
 import 'package:mediavore/core/domain/entities/actor_details.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
@@ -10,21 +10,23 @@ import 'package:mediavore/core/error/exceptions.dart';
 @lazySingleton
 class MediaRemoteDataSource {
   final Dio dio;
-  final String apiToken;
+  final SharedPreferences prefs;
+
+  String get _apiToken => prefs.getString('tmdbApiKey') ?? '';
 
   /// Creates a new instance of [MediaRemoteDataSource].
   ///
   /// Requires a [Dio] to make network requests and an [apiToken] for TMDB API.
   /// If [apiToken] is not provided, it will be read from the environment variable 'TMDB_API_TOKEN'.
   @factoryMethod
-  factory MediaRemoteDataSource({required Dio dio, String? apiToken}) {
+  factory MediaRemoteDataSource({required Dio dio, required SharedPreferences prefs}) {
     return MediaRemoteDataSource._internal(
       dio: dio,
-      apiToken: apiToken ?? dotenv.env['TMDB_API_TOKEN'] ?? '',
+      prefs: prefs,
     );
   }
 
-  MediaRemoteDataSource._internal({required this.dio, required this.apiToken});
+  MediaRemoteDataSource._internal({required this.dio, required this.prefs});
 
   /// Searches for movies and series on the TMDB API, supporting optional filters.
   Future<List<MediaItem>> searchMedia(
@@ -56,7 +58,7 @@ class MediaRemoteDataSource {
       final response = await dio.get(
         'https://api.themoviedb.org/3/search/$path',
         queryParameters: params,
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
 
       final List results = response.data['results'];
@@ -108,7 +110,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final data = Map<String, dynamic>.from(response.data);
       data['media_type'] = path;
@@ -142,7 +144,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/tv/$tvId/season/$seasonNumber',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data;
     } on DioException catch (e) {
@@ -165,7 +167,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id/credits',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data;
     } on DioException catch (e) {
@@ -194,7 +196,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/person/$actorId',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return ActorDetails.fromJson(response.data);
     } on DioException catch (e) {
@@ -250,7 +252,7 @@ class MediaRemoteDataSource {
       final response = await dio.get(
         'https://api.themoviedb.org/3/discover/$path',
         queryParameters: params,
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
 
       final List results = response.data['results'];
@@ -304,7 +306,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/person/$actorId/combined_credits',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['cast'];
       return results.map((m) => MediaItem.fromJson(m)).toList();
@@ -361,7 +363,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id/similar',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['results'];
       return results.map((m) {
@@ -379,7 +381,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/collection/$collectionId',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['parts'] ?? [];
       return results.map((m) {
@@ -397,7 +399,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id/recommendations',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['results'];
       return results.map((m) {
@@ -415,7 +417,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id/watch/providers',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data['results'] as Map<String, dynamic>;
     } catch (e) {
@@ -428,7 +430,7 @@ class MediaRemoteDataSource {
     try {
       final response = await dio.get(
         'https://api.themoviedb.org/3/$path/$id/videos',
-        options: Options(headers: {'Authorization': 'Bearer $apiToken'}),
+        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['results'];
       return results.cast<Map<String, dynamic>>();

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -165,6 +165,21 @@ class SettingsPage extends StatelessWidget {
             },
           ),
           const Divider(),
+          const _SectionHeader(title: 'API Configuration'),
+          ListTile(
+            leading: const Icon(Icons.key),
+            title: const Text('TMDB API Key'),
+            subtitle: Text(
+              settings.tmdbApiKey.isEmpty
+                  ? 'Not set'
+                  : '••••••••${settings.tmdbApiKey.length > 4 ? settings.tmdbApiKey.substring(settings.tmdbApiKey.length - 4) : ''}',
+            ),
+            trailing: const Icon(Icons.edit),
+            onTap: () {
+              _showApiKeyDialog(context, settings);
+            },
+          ),
+          const Divider(),
           const _SectionHeader(title: 'About'),
           const AboutListTile(
             icon: Icon(Icons.info_outline),
@@ -186,6 +201,39 @@ class SettingsPage extends StatelessWidget {
       case ThemeMode.dark:
         return 'Dark';
     }
+  }
+
+  void _showApiKeyDialog(BuildContext context, SettingsProvider settings) {
+    final controller = TextEditingController(text: settings.tmdbApiKey);
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('TMDB API Key'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(
+              hintText: 'Enter your API key here',
+              border: OutlineInputBorder(),
+            ),
+            obscureText: true,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                settings.setTmdbApiKey(controller.text.trim());
+                Navigator.pop(context);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
   }
 
   IconData _getThemeModeIcon(ThemeMode mode) {

--- a/lib/features/settings/presentation/providers/settings_provider.dart
+++ b/lib/features/settings/presentation/providers/settings_provider.dart
@@ -18,6 +18,7 @@ class SettingsProvider with ChangeNotifier {
   int _lightAppThemeIndex = 0;
   int _darkAppThemeIndex = 0;
   ThemeMode _themeMode = ThemeMode.system;
+  String _tmdbApiKey = '';
 
   DisplayMode get displayMode => _displayMode;
   double get gridSize => _gridSize;
@@ -26,6 +27,7 @@ class SettingsProvider with ChangeNotifier {
   int get lightAppThemeIndex => _lightAppThemeIndex;
   int get darkAppThemeIndex => _darkAppThemeIndex;
   ThemeMode get themeMode => _themeMode;
+  String get tmdbApiKey => _tmdbApiKey;
 
   AppPalette get lightPalette => lightThemes[_lightAppThemeIndex].palette;
   AppPalette get darkPalette => darkThemes[_darkAppThemeIndex].palette;
@@ -56,6 +58,14 @@ class SettingsProvider with ChangeNotifier {
     }
     _themeMode = ThemeMode.values[themeModeIndex];
 
+    _tmdbApiKey = _prefs.getString('tmdbApiKey') ?? '';
+
+    notifyListeners();
+  }
+
+  Future<void> setTmdbApiKey(String apiKey) async {
+    _tmdbApiKey = apiKey;
+    await _prefs.setString('tmdbApiKey', apiKey);
     notifyListeners();
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mediavore/core/di/injection.dart';
 import 'package:mediavore/core/di/injection.config.dart';
 import 'package:mediavore/features/achievements/presentation/providers/achievement_provider.dart';
@@ -15,12 +14,6 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   try {
-    try {
-      await dotenv.load(fileName: ".env");
-    } catch (e) {
-      debugPrint('Warning: .env file not found or failed to load: $e');
-    }
-
     // DefinitionsLoader should be provided by generated DI (injection.config.dart).
     // Avoid manual registration here; run codegen to ensure it's registered.
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -358,14 +358,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
-  flutter_dotenv:
-    dependency: "direct main"
-    description:
-      name: flutter_dotenv
-      sha256: b7c7be5cd9f6ef7a78429cabd2774d3c4af50e79cb2b7593e3d5d763ef95c61b
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.2.1"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   dio: ^5.4.3
-  flutter_dotenv: ^5.1.0
   provider: ^6.1.2
   shared_preferences: ^2.2.3
   equatable: ^2.0.5

--- a/test/features/media_details/presentation/pages/actor_detail_page_test.dart
+++ b/test/features/media_details/presentation/pages/actor_detail_page_test.dart
@@ -6,7 +6,6 @@ import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/theme/app_palette.dart';
 import 'package:mediavore/features/media_details/presentation/pages/actor_detail_page.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mocktail/mocktail.dart';
 import '../../../../helpers/mocks.dart';
 
@@ -15,8 +14,7 @@ void main() {
 
   setUp(() {
     mockMediaRepository = MockMediaRepository();
-    dotenv.testLoad(fileInput: 'TMDB_API_TOKEN=mock_token');
-    if (locator.isRegistered<MediaRepository>()) {
+        if (locator.isRegistered<MediaRepository>()) {
       locator.unregister<MediaRepository>();
     }
     locator.registerLazySingleton<MediaRepository>(() => mockMediaRepository);

--- a/test/features/media_details/presentation/pages/media_detail_page_test.dart
+++ b/test/features/media_details/presentation/pages/media_detail_page_test.dart
@@ -11,7 +11,6 @@ import 'package:mediavore/features/media_details/presentation/pages/media_detail
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
 import '../../../../helpers/mocks.dart';
@@ -58,8 +57,7 @@ void main() {
 
     searchProvider = SearchProvider(mockMediaRepository);
     settingsProvider = SettingsProvider(mockSharedPreferences);
-    dotenv.testLoad(fileInput: 'TMDB_API_TOKEN=mock_token');
-
+    
     if (locator.isRegistered<MediaRepository>()) {
       locator.unregister<MediaRepository>();
     }

--- a/test/features/search/data/datasources/media_remote_data_source_test.dart
+++ b/test/features/search/data/datasources/media_remote_data_source_test.dart
@@ -1,3 +1,4 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
@@ -8,10 +9,13 @@ import '../../../../helpers/mocks.dart';
 void main() {
   late MediaRemoteDataSource dataSource;
   late MockDio mockDio;
+  late MockSharedPreferences mockPrefs;
 
   setUp(() {
     mockDio = MockDio();
-    dataSource = MediaRemoteDataSource(dio: mockDio, apiToken: 'mock_token');
+    mockPrefs = MockSharedPreferences();
+    when(() => mockPrefs.getString('tmdbApiKey')).thenReturn('mock_token');
+    dataSource = MediaRemoteDataSource(dio: mockDio, prefs: mockPrefs);
   });
 
   group('searchMedia with Filters', () {
@@ -171,3 +175,5 @@ void main() {
     });
   });
 }
+
+

--- a/test/features/search/data/repositories/import_all_data_integration_test.dart
+++ b/test/features/search/data/repositories/import_all_data_integration_test.dart
@@ -1,4 +1,6 @@
+import 'package:shared_preferences/shared_preferences.dart';
 import 'dart:io';
+import 'package:mocktail/mocktail.dart';
 
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -16,12 +18,15 @@ import 'package:mediavore/features/search/domain/repositories/media_repository.d
 
 import 'package:mediavore/core/utils/export_import_serializer.dart';
 
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
 void main() {
   late Isar isar;
   late MediaListLocalDataSource local;
   late MediaCache cache;
   late MediaRepositoryImpl repo;
   late String tempPath;
+  late MockSharedPreferences mockPrefs;
 
   setUpAll(() async {
     await Isar.initializeIsarCore(download: true);
@@ -45,7 +50,9 @@ void main() {
     );
     local = MediaListLocalDataSource(isar);
     cache = MediaCache(isar);
-    final remote = MediaRemoteDataSource(dio: Dio(), apiToken: '');
+    mockPrefs = MockSharedPreferences();
+    when(() => mockPrefs.getString('tmdbApiKey')).thenReturn('mock_token');
+    final remote = MediaRemoteDataSource(dio: Dio(), prefs: mockPrefs);
     repo = MediaRepositoryImpl(
       remoteDataSource: remote,
       localDataSource: local,

--- a/test/features/search/presentation/pages/discovery_page_test.dart
+++ b/test/features/search/presentation/pages/discovery_page_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/theme/app_palette.dart';
 import 'package:mediavore/features/discovery/presentation/pages/discovery_page.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
 import 'package:mocktail/mocktail.dart';
@@ -86,8 +85,7 @@ void main() {
 
     searchProvider = SearchProvider(mockMediaRepository);
     settingsProvider = SettingsProvider(mockSharedPreferences);
-    dotenv.testLoad(fileInput: 'TMDB_API_TOKEN=mock_token');
-  });
+      });
 
   Widget createWidgetUnderTest() {
     return MultiProvider(

--- a/test/features/search/presentation/pages/search_page_test.dart
+++ b/test/features/search/presentation/pages/search_page_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/theme/app_palette.dart';
 import 'package:mediavore/features/search/presentation/pages/search_page.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
 import 'package:mocktail/mocktail.dart';
@@ -96,8 +95,7 @@ void main() {
     searchProvider = SearchProvider(mockMediaRepository);
     settingsProvider = SettingsProvider(mockSharedPreferences);
     searchTrigger = ValueNotifier<int>(0);
-    dotenv.testLoad(fileInput: 'TMDB_API_TOKEN=mock_token');
-  });
+      });
 
   tearDown(() {
     searchTrigger.dispose();


### PR DESCRIPTION
Closes #19

- Removed `flutter_dotenv` dependency and all related initialization logic from `main.dart` and tests.
- Added the ability to view and edit the TMDB API key directly from the Settings page via a new dialog.
- Updated `SettingsProvider` to manage the persistence of the `tmdbApiKey` using `SharedPreferences`.
- Refactored `MediaRemoteDataSource` to retrieve the API key dynamically from `SharedPreferences` instead of static environment variables.
- Updated dependency injection and unit/integration tests to accommodate the change from `apiToken` strings to `SharedPreferences` mocks.