### PR TITLE
build(android): update subproject compileSdkVersion to 36

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -14,15 +14,20 @@ rootProject.layout.buildDirectory.value(newBuildDir)
 subprojects {
     val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
     project.layout.buildDirectory.value(newSubprojectBuildDir)
-    
+
     // Workaround for plugins that haven't migrated to namespace-based build (AGP 8.0+)
     afterEvaluate {
         if (project.hasProperty("android")) {
             val android = project.extensions.findByName("android") as? com.android.build.gradle.BaseExtension
-            if (android != null && android.namespace == null) {
-                // Use the package name from manifest if available, or fallback to project name
-                android.namespace = project.group.toString().takeIf { it.isNotEmpty() } 
-                    ?: "dev.isar.${project.name.replace("-", "_")}"
+            if (android != null) {
+                // Force compileSdk to a recent version to avoid Android resource linking errors (e.g., lStar not found)
+                android.compileSdkVersion(36)
+
+                if (android.namespace == null) {
+                    // Use the package name from manifest if available, or fallback to project name
+                    android.namespace = project.group.toString().takeIf { it.isNotEmpty() }
+                        ?: "dev.isar.${project.name.replace("-", "_")}"
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #115 

- Forced `compileSdkVersion` to 36 for all subprojects to resolve Android resource linking errors (e.g., missing `lStar` attribute).
- Refactored the `afterEvaluate` block to ensure the SDK version is updated regardless of whether a namespace is already defined.

