### PR TITLE
feat(search): implement reactive updates for notified items

### DIFF
--- a/lib/features/media_details/data/datasources/media_list_local_data_source.dart
+++ b/lib/features/media_details/data/datasources/media_list_local_data_source.dart
@@ -527,6 +527,10 @@ class MediaListLocalDataSource {
     return await _isar.notifiedItemModels.where().findAll();
   }
 
+  Stream<void> watchNotifiedItems() {
+    return _isar.notifiedItemModels.watchLazy();
+  }
+
   Future<void> importLikedItems(
     List<LikedItem> items, {
     required ImportMode mode,

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -1121,6 +1121,11 @@ class MediaRepositoryImpl implements MediaRepository {
   }
 
   @override
+  Stream<void> watchNotifiedItems() {
+    return localDataSource.watchNotifiedItems();
+  }
+
+  @override
   Future<void> optOutSeries(
     int tmdbId, {
     int? seasonNumber,

--- a/lib/features/search/domain/repositories/media_repository.dart
+++ b/lib/features/search/domain/repositories/media_repository.dart
@@ -149,6 +149,9 @@ abstract class MediaRepository {
   /// Gets all notified media entries.
   Future<List<NotifiedItem>> getNotifiedItems();
 
+  /// Watches for changes in notified items.
+  Stream<void> watchNotifiedItems();
+
   /// Force refreshes all notified items from network.
   Future<void> refreshNotifiedItems();
 

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/media_details.dart';
@@ -6,6 +8,7 @@ import 'package:mediavore/features/search/domain/repositories/media_repository.d
 
 class SearchProvider with ChangeNotifier {
   final MediaRepository repository;
+  StreamSubscription<void>? _notifiedItemsSubscription;
 
   SearchProvider(this.repository) {
     _init();
@@ -122,6 +125,16 @@ class SearchProvider with ChangeNotifier {
     await loadLikedStatus();
     await loadNotifiedItems();
     await loadQuickAddItems();
+
+    _notifiedItemsSubscription = repository.watchNotifiedItems().listen((_) {
+      loadNotifiedItems();
+    });
+  }
+
+  @override
+  void dispose() {
+    _notifiedItemsSubscription?.cancel();
+    super.dispose();
   }
 
   void setSelectedTab(int index) {


### PR DESCRIPTION
Closes #109

- Added `watchNotifiedItems` stream to `MediaRepository` and its implementation to track changes in notified media.
- Implemented lazy watching of notified item models in `MediaListLocalDataSource` using Isar.
- Updated `SearchProvider` to subscribe to notified item changes and automatically trigger data reloads.
- Added proper disposal of the stream subscription in `SearchProvider` to prevent memory leaks.