### PR TITLE
refactor(settings): migrate export file format from ZIP to MDV

### DIFF
--- a/lib/features/search/domain/repositories/media_repository.dart
+++ b/lib/features/search/domain/repositories/media_repository.dart
@@ -121,7 +121,7 @@ abstract class MediaRepository {
   /// Manually triggers a full cache fill (pre-caching lists and recent seen).
   Future<void> fillCache();
 
-  /// Exports all user data (seen, likes, notifications, lists) as a single zip archive byte list.
+  /// Exports all user data (seen, likes, notifications, lists) as a single MDV archive byte list.
   Future<List<int>> exportAllData();
 
   /// Imports an export archive produced by `exportAllData`.

--- a/lib/features/settings/presentation/pages/data_cache_settings_page.dart
+++ b/lib/features/settings/presentation/pages/data_cache_settings_page.dart
@@ -126,14 +126,14 @@ class DataCacheSettingsPage extends StatelessWidget {
                 leading: const Icon(Icons.cloud_upload),
                 title: const Text('Export All Data'),
                 subtitle: const Text(
-                  'Export seen, likes, notifications and lists as a single ZIP file.',
+                  'Export seen, likes, notifications and lists as a single MDV file.',
                 ),
                 onTap: () async {
                   final zipBytes = await provider.exportAllData();
                   if (!context.mounted) return;
                   final tempDir = await getTemporaryDirectory();
                   final fileName =
-                      'mediavore_export_${DateTime.now().millisecondsSinceEpoch}.zip';
+                      'mediavore_export_${DateTime.now().millisecondsSinceEpoch}.mdv';
                   final tempFile = File('${tempDir.path}/$fileName');
                   await tempFile.writeAsBytes(zipBytes);
                   if (context.mounted) {
@@ -163,7 +163,7 @@ class DataCacheSettingsPage extends StatelessWidget {
                                 await Share.shareXFiles([
                                   XFile(
                                     tempFile.path,
-                                    mimeType: 'application/zip',
+                                    mimeType: 'application/octet-stream',
                                   ),
                                 ], text: 'MediaVore Export');
                               },
@@ -179,7 +179,7 @@ class DataCacheSettingsPage extends StatelessWidget {
                 leading: const Icon(Icons.file_download),
                 title: const Text('Import All Data'),
                 subtitle: const Text(
-                  'Import seen, likes, notifications and lists from an export ZIP.',
+                  'Import seen, likes, notifications and lists from an export MDV or ZIP.',
                 ),
                 onTap: () => _importAllDataWithPreview(context, provider),
               ),
@@ -324,15 +324,25 @@ class DataCacheSettingsPage extends StatelessWidget {
     // ignore: avoid_print
     print('_importAllDataWithPreview called');
     final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['zip'],
+      type: FileType.any,
       initialDirectory: Platform.isAndroid ? _defaultPath : null,
     );
 
     if (!context.mounted) return;
 
     if (result != null && result.files.single.path != null) {
-      final file = File(result.files.single.path!);
+      final path = result.files.single.path!;
+      if (!path.toLowerCase().endsWith('.mdv') &&
+          !path.toLowerCase().endsWith('.zip')) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Please select a valid .mdv or .zip export file.'),
+          ),
+        );
+        return;
+      }
+
+      final file = File(path);
       final bytes = await file.readAsBytes();
 
       try {


### PR DESCRIPTION
Closes #126 

- Updated `MediaRepository` documentation to reflect the move from ZIP to MDV archives.
- Changed the export file extension to `.mdv` and updated the MIME type to `application/octet-stream`.
- Modified the import logic to support both `.mdv` and `.zip` extensions for backward compatibility.
- Updated UI text in `DataCacheSettingsPage` to reflect the new file format.
- Improved file picker logic to allow any file type while implementing manual extension validation.