### PR TITLE
fix(search): resolve synchronization, UI overflow, and state bugs in My Lists

### DIFF
--- a/lib/features/media_details/data/datasources/media_list_local_data_source.dart
+++ b/lib/features/media_details/data/datasources/media_list_local_data_source.dart
@@ -30,17 +30,19 @@ class MediaListLocalDataSource {
           .findFirst();
 
       if (existing == null) {
-        final count = await _isar.mediaListItems
+        final maxItem = await _isar.mediaListItems
             .filter()
             .listNameEqualTo(listName)
-            .count();
+            .sortByPositionDesc()
+            .findFirst();
+        final nextPosition = maxItem != null ? maxItem.position + 1 : 0;
 
         final item = MediaListItem(
           id: id,
           type: type,
           listName: listName,
           title: title,
-          position: count,
+          position: nextPosition,
         );
         await _isar.mediaListItems.put(item);
       }

--- a/lib/features/media_details/data/datasources/media_list_local_data_source.dart
+++ b/lib/features/media_details/data/datasources/media_list_local_data_source.dart
@@ -120,7 +120,7 @@ class MediaListLocalDataSource {
   }
 
   Future<void> deleteList(String name) async {
-    if (name == 'watchlist') return; // Cannot delete watchlist
+    if (name.toLowerCase() == 'watchlist') return; // Cannot delete watchlist
     await _isar.writeTxn(() async {
       await _isar.userLists.filter().nameEqualTo(name).deleteAll();
       await _isar.mediaListItems.filter().listNameEqualTo(name).deleteAll();

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -910,12 +910,15 @@ class SavedMediaPageState extends State<SavedMediaPage> {
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [
-                Text(
-                  _isEditMode
-                      ? '${_selectedItems.length} selected'
-                      : (_selectedList == 'watchlist'
-                            ? 'Watchlist'
-                            : _selectedList),
+                Flexible(
+                  child: Text(
+                    _isEditMode
+                        ? '${_selectedItems.length} selected'
+                        : (_selectedList == 'watchlist'
+                              ? 'Watchlist'
+                              : _selectedList),
+                    overflow: TextOverflow.ellipsis,
+                  ),
                 ),
                 if (!_isEditMode) const Icon(Icons.arrow_drop_down),
               ],
@@ -1071,11 +1074,12 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           settings: settings,
           isEditMode: _isEditMode,
           isSelected: isSelected,
-          onTap: () {
+          onTap: () async {
             if (_isEditMode) {
               _toggleItemSelection(item);
             } else {
-              MediaDetailPage.show(context, item);
+              await MediaDetailPage.show(context, item);
+              loadSavedMedia();
             }
           },
           onLongPress: () {
@@ -1165,11 +1169,12 @@ class SavedMediaPageState extends State<SavedMediaPage> {
             provider: provider,
             isSelected: isSelected,
             isEditMode: _isEditMode,
-            onTap: () {
+            onTap: () async {
               if (_isEditMode) {
                 _toggleItemSelection(item);
               } else {
-                MediaDetailPage.show(context, item);
+                await MediaDetailPage.show(context, item);
+                loadSavedMedia();
               }
             },
             onLongPress: _isEditMode
@@ -1195,6 +1200,7 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           key: ValueKey('${item.id}_${item.mediaType.name}'),
           item: item,
           provider: provider,
+          onReturn: loadSavedMedia,
         );
       },
     );
@@ -1228,7 +1234,11 @@ class SavedMediaPageState extends State<SavedMediaPage> {
 
                     return ListTile(
                       leading: _buildListPreviewIcon(previews, provider),
-                      title: Text(name == 'watchlist' ? 'Watchlist' : name),
+                      title: Text(
+                        name == 'watchlist' ? 'Watchlist' : name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
                       subtitle: Text('$count items'),
                       selected: name == _selectedList,
                       trailing: (name != 'watchlist')
@@ -1242,7 +1252,11 @@ class SavedMediaPageState extends State<SavedMediaPage> {
                                   ),
                                   onPressed: () {
                                     Navigator.pop(context);
-                                    _showDeleteListConfirm(context, provider, name);
+                                    _showDeleteListConfirm(
+                                      context,
+                                      provider,
+                                      name,
+                                    );
                                   },
                                 ),
                               ],
@@ -1557,11 +1571,13 @@ class _MediaGridItem extends StatelessWidget {
 class _MediaSwipeItem extends StatelessWidget {
   final MediaItem item;
   final SearchProvider provider;
+  final VoidCallback onReturn;
 
   const _MediaSwipeItem({
     super.key,
     required this.item,
     required this.provider,
+    required this.onReturn,
   });
 
   @override
@@ -1575,7 +1591,10 @@ class _MediaSwipeItem extends StatelessWidget {
           children: [
             Expanded(
               child: InkWell(
-                onTap: () => MediaDetailPage.show(context, item),
+                onTap: () async {
+                  await MediaDetailPage.show(context, item);
+                  onReturn();
+                },
                 borderRadius: const BorderRadius.vertical(
                   top: Radius.circular(16),
                 ),
@@ -1597,7 +1616,10 @@ class _MediaSwipeItem extends StatelessWidget {
                   const SizedBox(width: 56), // Balances the larger LikeButton
                   Expanded(
                     child: InkWell(
-                      onTap: () => MediaDetailPage.show(context, item),
+                      onTap: () async {
+                        await MediaDetailPage.show(context, item);
+                        onReturn();
+                      },
                       child: Text(
                         item.title,
                         style: Theme.of(context).textTheme.headlineSmall,

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -43,6 +43,10 @@ class SavedMediaPageState extends State<SavedMediaPage> {
   Uint8List? _croppedLogoBytes;
   Color? _lastThemeColor;
 
+  // Sync state tracking for external list mutations
+  String _lastSelectedList = 'watchlist';
+  Set<String> _lastListSet = {};
+
   // Edit Mode State
   bool _isEditMode = false;
   final Set<String> _selectedItems = {};
@@ -881,6 +885,18 @@ class SavedMediaPageState extends State<SavedMediaPage> {
     final provider = Provider.of<SearchProvider>(context);
     final settings = Provider.of<SettingsProvider>(context);
     final colors = context.appColors;
+
+    final currentListSet = provider.getListEntriesCached(_selectedList).toSet();
+    if (_lastSelectedList != _selectedList) {
+      _lastSelectedList = _selectedList;
+      _lastListSet = currentListSet;
+    } else if (currentListSet.length != _lastListSet.length ||
+        !currentListSet.containsAll(_lastListSet)) {
+      _lastListSet = currentListSet;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) loadSavedMedia();
+      });
+    }
 
     return PopScope(
       canPop: !_isEditMode,

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -149,6 +149,9 @@ class SavedMediaPageState extends State<SavedMediaPage> {
     if (_selectedList != 'watchlist') {
       setState(() {
         _selectedList = 'watchlist';
+        _currentItems.clear();
+        _sortMethod = SortMethod.manual;
+        _isReversed = false;
         _isEditMode = false;
         _selectedItems.clear();
       });
@@ -244,7 +247,7 @@ class SavedMediaPageState extends State<SavedMediaPage> {
         .toList();
 
     for (final item in itemsToRemove) {
-      await provider.toggleInList(item, _selectedList);
+      await provider.removeFromList(item, _selectedList);
     }
 
     setState(() {
@@ -1018,16 +1021,34 @@ class SavedMediaPageState extends State<SavedMediaPage> {
 
           // Map indices to _currentItems to handle filtering correctly
           final oldPersistentIndex = _currentItems.indexOf(item);
-          _currentItems.removeAt(oldPersistentIndex);
+          if (oldPersistentIndex != -1) {
+            _currentItems.removeAt(oldPersistentIndex);
+          }
 
           if (newIndex < items.length - 1) {
             final nextItemInFiltered = items[newIndex + 1];
             final nextPersistentIndex = _currentItems.indexOf(
               nextItemInFiltered,
             );
-            _currentItems.insert(nextPersistentIndex, item);
+            if (nextPersistentIndex != -1) {
+              _currentItems.insert(nextPersistentIndex, item);
+            } else {
+              _currentItems.add(item);
+            }
           } else {
-            _currentItems.add(item);
+            if (items.length > 1 && newIndex > 0) {
+              final previousItemInFiltered = items[newIndex - 1];
+              final prevPersistentIndex = _currentItems.indexOf(
+                previousItemInFiltered,
+              );
+              if (prevPersistentIndex != -1) {
+                _currentItems.insert(prevPersistentIndex + 1, item);
+              } else {
+                _currentItems.add(item);
+              }
+            } else {
+              _currentItems.add(item);
+            }
           }
         });
 
@@ -1094,16 +1115,34 @@ class SavedMediaPageState extends State<SavedMediaPage> {
 
           // Map indices to _currentItems to handle filtering correctly
           final oldPersistentIndex = _currentItems.indexOf(item);
-          _currentItems.removeAt(oldPersistentIndex);
+          if (oldPersistentIndex != -1) {
+            _currentItems.removeAt(oldPersistentIndex);
+          }
 
           if (newIndex < items.length - 1) {
             final nextItemInFiltered = items[newIndex + 1];
             final nextPersistentIndex = _currentItems.indexOf(
               nextItemInFiltered,
             );
-            _currentItems.insert(nextPersistentIndex, item);
+            if (nextPersistentIndex != -1) {
+              _currentItems.insert(nextPersistentIndex, item);
+            } else {
+              _currentItems.add(item);
+            }
           } else {
-            _currentItems.add(item);
+            if (items.length > 1 && newIndex > 0) {
+              final previousItemInFiltered = items[newIndex - 1];
+              final prevPersistentIndex = _currentItems.indexOf(
+                previousItemInFiltered,
+              );
+              if (prevPersistentIndex != -1) {
+                _currentItems.insert(prevPersistentIndex + 1, item);
+              } else {
+                _currentItems.add(item);
+              }
+            } else {
+              _currentItems.add(item);
+            }
           }
         });
 
@@ -1193,15 +1232,20 @@ class SavedMediaPageState extends State<SavedMediaPage> {
                       subtitle: Text('$count items'),
                       selected: name == _selectedList,
                       trailing: (name != 'watchlist')
-                          ? IconButton(
-                              icon: Icon(
-                                Icons.delete_outline,
-                                color: colors.error,
-                              ),
-                              onPressed: () {
-                                Navigator.pop(context);
-                                _showDeleteListConfirm(context, provider, name);
-                              },
+                          ? Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                IconButton(
+                                  icon: Icon(
+                                    Icons.delete_outline,
+                                    color: colors.error,
+                                  ),
+                                  onPressed: () {
+                                    Navigator.pop(context);
+                                    _showDeleteListConfirm(context, provider, name);
+                                  },
+                                ),
+                              ],
                             )
                           : null,
                       onTap: () {
@@ -1309,10 +1353,14 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           ),
           TextButton(
             onPressed: () async {
-              if (controller.text.isNotEmpty) {
-                await provider.createList(controller.text);
+              final trimmedName = controller.text.trim();
+              if (trimmedName.isNotEmpty) {
+                await provider.createList(trimmedName);
                 setState(() {
-                  _selectedList = controller.text;
+                  _selectedList = trimmedName;
+                  _currentItems.clear();
+                  _sortMethod = SortMethod.manual;
+                  _isReversed = false;
                   _isEditMode = false;
                   _selectedItems.clear();
                 });
@@ -1347,9 +1395,12 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           ),
           TextButton(
             onPressed: () async {
-              if (_selectedList == listName) {
+              if (mounted && _selectedList == listName) {
                 setState(() {
                   _selectedList = 'watchlist';
+                  _currentItems.clear();
+                  _sortMethod = SortMethod.manual;
+                  _isReversed = false;
                   _isEditMode = false;
                   _selectedItems.clear();
                 });
@@ -1545,7 +1596,7 @@ class _MediaSwipeItem extends StatelessWidget {
                 children: [
                   const SizedBox(width: 56), // Balances the larger LikeButton
                   Expanded(
-                      child: InkWell(
+                    child: InkWell(
                       onTap: () => MediaDetailPage.show(context, item),
                       child: Text(
                         item.title,

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -1152,7 +1152,11 @@ class SavedMediaPageState extends State<SavedMediaPage> {
       itemCount: items.length,
       itemBuilder: (context, index) {
         final item = items[index];
-        return _MediaSwipeItem(item: item, provider: provider);
+        return _MediaSwipeItem(
+          key: ValueKey('${item.id}_${item.mediaType.name}'),
+          item: item,
+          provider: provider,
+        );
       },
     );
   }
@@ -1203,6 +1207,9 @@ class SavedMediaPageState extends State<SavedMediaPage> {
                       onTap: () {
                         setState(() {
                           _selectedList = name;
+                          _currentItems.clear();
+                          _sortMethod = SortMethod.manual;
+                          _isReversed = false;
                           _isEditMode = false;
                           _selectedItems.clear();
                         });
@@ -1500,7 +1507,11 @@ class _MediaSwipeItem extends StatelessWidget {
   final MediaItem item;
   final SearchProvider provider;
 
-  const _MediaSwipeItem({required this.item, required this.provider});
+  const _MediaSwipeItem({
+    super.key,
+    required this.item,
+    required this.provider,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -1011,12 +1011,51 @@ class SavedMediaPageState extends State<SavedMediaPage> {
     SearchProvider provider,
     SettingsProvider settings,
   ) {
+    if (_sortMethod != SortMethod.manual || _isEditMode) {
+      return ListView.builder(
+        itemCount: items.length,
+        clipBehavior: Clip.none,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          final isSelected = _selectedItems.contains(
+            '${item.id}:${item.mediaType.name}',
+          );
+
+          return _MediaListTile(
+            key: ValueKey('${item.id}_${item.mediaType.name}'),
+            index: index,
+            item: item,
+            provider: provider,
+            settings: settings,
+            isEditMode: _isEditMode,
+            isSelected: isSelected,
+            isManualSort: false,
+            onTap: () async {
+              if (_isEditMode) {
+                _toggleItemSelection(item);
+              } else {
+                await MediaDetailPage.show(context, item);
+                loadSavedMedia();
+              }
+            },
+            onLongPress: () {
+              if (!_isEditMode) {
+                setState(() {
+                  _isEditMode = true;
+                  _selectedItems.add('${item.id}:${item.mediaType.name}');
+                });
+              }
+            },
+          );
+        },
+      );
+    }
+
     return ReorderableListView.builder(
       itemCount: items.length,
       clipBehavior: Clip.none,
+      buildDefaultDragHandles: false,
       onReorder: (oldIndex, newIndex) async {
-        if (_sortMethod != SortMethod.manual) return;
-
         setState(() {
           if (newIndex > oldIndex) newIndex -= 1;
           final item = items.removeAt(oldIndex);
@@ -1074,6 +1113,7 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           settings: settings,
           isEditMode: _isEditMode,
           isSelected: isSelected,
+          isManualSort: true,
           onTap: () async {
             if (_isEditMode) {
               _toggleItemSelection(item);
@@ -1100,6 +1140,50 @@ class SavedMediaPageState extends State<SavedMediaPage> {
     SearchProvider provider,
     SettingsProvider settings,
   ) {
+    if (_sortMethod != SortMethod.manual || _isEditMode) {
+      return GridView.builder(
+        padding: const EdgeInsets.all(8),
+        clipBehavior: Clip.none,
+        gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: settings.gridSize.round(),
+          childAspectRatio: 0.66,
+          crossAxisSpacing: 4,
+          mainAxisSpacing: 4,
+        ),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          final isSelected = _selectedItems.contains(
+            '${item.id}:${item.mediaType.name}',
+          );
+
+          return _MediaGridItem(
+            key: ValueKey('${item.id}_${item.mediaType.name}'),
+            item: item,
+            provider: provider,
+            isSelected: isSelected,
+            isEditMode: _isEditMode,
+            onTap: () async {
+              if (_isEditMode) {
+                _toggleItemSelection(item);
+              } else {
+                await MediaDetailPage.show(context, item);
+                loadSavedMedia();
+              }
+            },
+            onLongPress: _isEditMode
+                ? null
+                : () {
+                    setState(() {
+                      _isEditMode = true;
+                      _selectedItems.add('${item.id}:${item.mediaType.name}');
+                    });
+                  },
+          );
+        },
+      );
+    }
+
     return ReorderableGridView.builder(
       padding: const EdgeInsets.all(8),
       clipBehavior: Clip.none,
@@ -1111,8 +1195,6 @@ class SavedMediaPageState extends State<SavedMediaPage> {
       ),
       itemCount: items.length,
       onReorder: (oldIndex, newIndex) async {
-        if (_sortMethod != SortMethod.manual) return;
-
         setState(() {
           final item = items.removeAt(oldIndex);
           items.insert(newIndex, item);
@@ -1368,7 +1450,8 @@ class SavedMediaPageState extends State<SavedMediaPage> {
           TextButton(
             onPressed: () async {
               final trimmedName = controller.text.trim();
-              if (trimmedName.isNotEmpty) {
+              if (trimmedName.isNotEmpty &&
+                  trimmedName.toLowerCase() != 'watchlist') {
                 await provider.createList(trimmedName);
                 setState(() {
                   _selectedList = trimmedName;
@@ -1438,6 +1521,7 @@ class _MediaListTile extends StatelessWidget {
   final SettingsProvider settings;
   final bool isEditMode;
   final bool isSelected;
+  final bool isManualSort;
   final VoidCallback onTap;
   final VoidCallback onLongPress;
 
@@ -1449,6 +1533,7 @@ class _MediaListTile extends StatelessWidget {
     required this.settings,
     required this.isEditMode,
     required this.isSelected,
+    required this.isManualSort,
     required this.onTap,
     required this.onLongPress,
   });
@@ -1490,10 +1575,12 @@ class _MediaListTile extends StatelessWidget {
           subtitle: Text('${item.releaseDate} • $lengthText'),
           trailing: isEditMode
               ? Checkbox(value: isSelected, onChanged: (_) => onTap())
-              : ReorderableDragStartListener(
+              : isManualSort
+              ? ReorderableDragStartListener(
                   index: index,
                   child: const Icon(Icons.drag_handle),
-                ),
+                )
+              : null,
         ),
       ),
     );
@@ -1509,6 +1596,7 @@ class _MediaGridItem extends StatelessWidget {
   final VoidCallback? onLongPress;
 
   const _MediaGridItem({
+    super.key,
     required this.item,
     required this.provider,
     required this.isSelected,

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -298,6 +298,22 @@ class SearchProvider with ChangeNotifier {
     notifyListeners();
   }
 
+  Future<void> removeFromList(MediaItem item, String listName) async {
+    final entry = '${item.id}:${item.mediaType.name}';
+    final currentEntries = _listEntries[listName] ?? [];
+    
+    if (currentEntries.contains(entry)) {
+      await repository.removeFromList(item.id, item.mediaType, listName);
+      _listEntries[listName] = currentEntries.where((e) => e != entry).toList();
+      if (listName == 'watchlist') {
+        _watchlistIds.remove(item.id.toString());
+      }
+      _listPreviews[listName] = await repository.getListPreviews(listName);
+      await updateCacheSize();
+      notifyListeners();
+    }
+  }
+
   Future<void> toggleWatchlist(MediaItem item) async {
     await toggleInList(item, 'watchlist');
   }
@@ -311,8 +327,8 @@ class SearchProvider with ChangeNotifier {
   Future<void> createList(String name) async {
     await repository.createList(name);
     await loadListNames();
-    _listEntries[name] = [];
-    _listPreviews[name] = [];
+    _listEntries[name] = await repository.getListEntries(name);
+    _listPreviews[name] = await repository.getListPreviews(name);
     notifyListeners();
   }
 

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -249,6 +249,10 @@ class SearchProvider with ChangeNotifier {
     await loadQuickAddItems();
   }
 
+  List<String> getListEntriesCached(String listName) {
+    return _listEntries[listName] ?? [];
+  }
+
   int getSeenCount(MediaItem item) {
     return _seenCounts['${item.id}:${item.mediaType.name}'] ?? 0;
   }
@@ -301,7 +305,7 @@ class SearchProvider with ChangeNotifier {
   Future<void> removeFromList(MediaItem item, String listName) async {
     final entry = '${item.id}:${item.mediaType.name}';
     final currentEntries = _listEntries[listName] ?? [];
-    
+
     if (currentEntries.contains(entry)) {
       await repository.removeFromList(item.id, item.mediaType, listName);
       _listEntries[listName] = currentEntries.where((e) => e != entry).toList();
@@ -778,7 +782,9 @@ class SearchProvider with ChangeNotifier {
 
     try {
       final seenItems = await repository.getSeenItems();
-      final itemsToUpdate = seenItems.where((i) => i.id != null && (i.runtime == null || i.runtime == 0)).toList();
+      final itemsToUpdate = seenItems
+          .where((i) => i.id != null && (i.runtime == null || i.runtime == 0))
+          .toList();
 
       int processed = 0;
       for (final item in itemsToUpdate) {
@@ -787,7 +793,10 @@ class SearchProvider with ChangeNotifier {
         notifyListeners();
 
         try {
-          final details = await repository.getMediaDetails(item.tmdbId, type: item.type);
+          final details = await repository.getMediaDetails(
+            item.tmdbId,
+            type: item.type,
+          );
 
           List<String>? newGenres = item.genres;
           if (newGenres == null || newGenres.isEmpty) {
@@ -816,7 +825,8 @@ class SearchProvider with ChangeNotifier {
             }
           }
 
-          if ((newRuntime != null && newRuntime > 0) || (newGenres != null && newGenres.isNotEmpty)) {
+          if ((newRuntime != null && newRuntime > 0) ||
+              (newGenres != null && newGenres.isNotEmpty)) {
             final updatedItem = item.copyWith(
               runtime: newRuntime,
               genres: newGenres,

--- a/test/features/media_details/data/datasources/media_list_local_data_source_test.dart
+++ b/test/features/media_details/data/datasources/media_list_local_data_source_test.dart
@@ -153,6 +153,46 @@ void main() {
       expect(lists, isNot(contains('Custom List')));
     });
 
+    test('should add to list and prevent position gaps on deletion', () async {
+      await dataSource.addToList(
+        id: 1,
+        type: 'movie',
+        listName: 'watchlist',
+        title: 'A',
+      );
+      await dataSource.addToList(
+        id: 2,
+        type: 'movie',
+        listName: 'watchlist',
+        title: 'B',
+      );
+      await dataSource.addToList(
+        id: 3,
+        type: 'movie',
+        listName: 'watchlist',
+        title: 'C',
+      );
+
+      final itemsBeforeDelete = await dataSource.getListItems('watchlist');
+      expect(itemsBeforeDelete.map((e) => e.position).toList(), [0, 1, 2]);
+
+      // Remove middle item
+      await dataSource.removeFromList(2, 'movie', 'watchlist');
+
+      // Add a new item
+      await dataSource.addToList(
+        id: 4,
+        type: 'movie',
+        listName: 'watchlist',
+        title: 'D',
+      );
+
+      final itemsAfterAdd = await dataSource.getListItems('watchlist');
+      // Positions should be preserved for existing items, and D appended to max + 1
+      expect(itemsAfterAdd.map((e) => e.position).toList(), [0, 2, 3]);
+      expect(itemsAfterAdd.map((e) => e.title).toList(), ['A', 'C', 'D']);
+    });
+
     test('should add to list and update position', () async {
       await dataSource.addToList(
         id: 1,

--- a/test/features/search/presentation/pages/saved_media_page_test.dart
+++ b/test/features/search/presentation/pages/saved_media_page_test.dart
@@ -54,6 +54,9 @@ void main() {
       () => mockMediaRepository.getNotifiedItems(),
     ).thenAnswer((_) async => []);
     when(
+      () => mockMediaRepository.watchNotifiedItems(),
+    ).thenAnswer((_) => const Stream.empty());
+    when(
       () => mockMediaRepository.getListPreviews(
         any(),
         limit: any(named: 'limit'),

--- a/test/features/search/presentation/pages/saved_media_page_test.dart
+++ b/test/features/search/presentation/pages/saved_media_page_test.dart
@@ -122,4 +122,78 @@ void main() {
     // Use matching by icon data since Icons.favorite is used in the widget
     expect(find.byIcon(Icons.favorite), findsOneWidget);
   });
+
+  testWidgets('displays very long list name without overflow exceptions', (
+    WidgetTester tester,
+  ) async {
+    const longName =
+        'This is a very very very very very very very very very very very very long list name';
+    when(
+      () => mockMediaRepository.getAllListNames(),
+    ).thenAnswer((_) async => ['watchlist', longName]);
+    when(
+      () => mockMediaRepository.getListEntries(any()),
+    ).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    // Force provider to load names
+    await searchProvider.loadListNames();
+    await tester.pumpAndSettle();
+
+    // Open list picker
+    await tester.tap(find.text('Watchlist').first);
+    await tester.pumpAndSettle();
+
+    // Select the long name list
+    await tester.tap(find.text(longName).first);
+    await tester.pumpAndSettle();
+
+    // Should render the long list name without exception
+    expect(tester.takeException(), isNull);
+    expect(find.text(longName), findsWidgets);
+  });
+
+  testWidgets('removing an item updates the list in real-time', (
+    WidgetTester tester,
+  ) async {
+    const item = MediaItem(
+      id: 1,
+      title: 'Inception',
+      overview: 'Overview',
+      releaseDate: '2010',
+      mediaType: MediaType.movie,
+    );
+
+    // Initial state with item
+    when(
+      () => mockMediaRepository.getListEntries('watchlist'),
+    ).thenAnswer((_) async => ['1:movie']);
+    when(
+      () => mockMediaRepository.getMediaDetails(1, type: MediaType.movie),
+    ).thenAnswer((_) async => MediaDetails(item: item, cast: []));
+    when(
+      () => mockMediaRepository.removeFromList(1, MediaType.movie, 'watchlist'),
+    ).thenAnswer((_) async {});
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Inception'), findsOneWidget);
+
+    // Long press to enter edit mode and select item
+    await tester.longPress(find.text('Inception'));
+    await tester.pumpAndSettle();
+
+    // Update mock to return empty list on reload
+    when(
+      () => mockMediaRepository.getListEntries('watchlist'),
+    ).thenAnswer((_) async => []);
+
+    // Tap delete icon to remove
+    await tester.tap(find.byIcon(Icons.delete).first);
+    await tester.pumpAndSettle();
+
+    // Item should no longer be visible
+    expect(find.text('Inception'), findsNothing);
+  });
 }

--- a/test/features/search/presentation/providers/search_provider_test.dart
+++ b/test/features/search/presentation/providers/search_provider_test.dart
@@ -52,6 +52,7 @@ void main() {
     ).thenAnswer((_) async => []);
     when(() => mockRepository.getLikedEntries()).thenAnswer((_) async => []);
     when(() => mockRepository.getNotifiedItems()).thenAnswer((_) async => []);
+    when(() => mockRepository.watchNotifiedItems()).thenAnswer((_) => const Stream.empty());
     when(
       () => mockRepository.toggleNotification(
         any(),


### PR DESCRIPTION
## Description
This PR resolves several lingering bugs within `SavedMediaPage` and list management, ensuring that users see perfectly synchronized data across tabs and no longer encounter UI crashes.

### Key Improvements
* **Real-Time Global Synchronization:** Fixed an issue where adding media from the Discover/Search tab wouldn't immediately appear in "My Lists". The UI now actively monitors global `SearchProvider` state changes and triggers a seamless data refresh.
* **Immediate Local Updates:** Returning from a `MediaDetailPage` now instantly reloads the list view, accurately reflecting any additions or removals made on the details screen.
* **Text Overflow Fix:** Extremely long custom list names no longer cause layout overflow exceptions (safely wrapped in `Flexible` with `TextOverflow.ellipsis`).
* **Drag-and-Drop Safety:** Drag handles and `ReorderableListView` features are now appropriately disabled while in edit mode or when using non-manual sorting (Date/Shuffle) to prevent accidental data corruption and application crashes.
* **Scope Cleanup:** Completely reverted the incomplete "rename list" feature to keep the application footprint stable and focused.

### Testing
* Added widget tests verifying that long list names render correctly without overflow exceptions.
* Added widget tests ensuring that item removals immediately update the active widget tree.