### PR TITLE
feat(media_details): refactor notification eligibility logic

### DIFF
--- a/lib/core/domain/entities/media_item.dart
+++ b/lib/core/domain/entities/media_item.dart
@@ -253,6 +253,23 @@ class MediaItem extends Equatable {
     );
   }
 
+  bool get canBeNotified {
+    if (mediaType == MediaType.tv) {
+      return status != 'Ended' && status != 'Canceled';
+    } else if (mediaType == MediaType.movie) {
+      if (releaseDate.isEmpty) {
+        return true;
+      }
+      try {
+        final date = DateTime.parse(releaseDate);
+        return date.isAfter(DateTime.now());
+      } catch (_) {
+        return true; // Malformed or missing date
+      }
+    }
+    return false;
+  }
+
   @override
   List<Object?> get props => [
     id,

--- a/lib/features/media_details/presentation/widgets/notify_button.dart
+++ b/lib/features/media_details/presentation/widgets/notify_button.dart
@@ -13,23 +13,7 @@ class NotifyButton extends StatelessWidget {
     return Consumer<SearchProvider>(
       builder: (context, provider, child) {
         final isNotified = provider.isNotified(item);
-
-        // Only show if not released or if it's a TV show (could have new episodes)
-        bool shouldShow = false;
-        if (item.mediaType == MediaType.tv) {
-          shouldShow = item.status != 'Ended' && item.status != 'Canceled';
-        } else if (item.mediaType == MediaType.movie) {
-          if (item.releaseDate.isEmpty) {
-            shouldShow = true;
-          } else {
-            try {
-              final releaseDate = DateTime.parse(item.releaseDate);
-              shouldShow = releaseDate.isAfter(DateTime.now());
-            } catch (_) {
-              shouldShow = true;
-            }
-          }
-        }
+        final shouldShow = item.canBeNotified;
 
         if (!shouldShow && !isNotified) return const SizedBox.shrink();
 

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -293,7 +293,9 @@ class SearchProvider with ChangeNotifier {
       _listEntries[listName] = [...currentEntries, entry];
       if (listName == 'watchlist') {
         _watchlistIds.add(item.id.toString());
-        await repository.toggleNotification(item, autoNotify: true);
+        if (item.canBeNotified) {
+          await repository.toggleNotification(item, autoNotify: true);
+        }
         await loadNotifiedItems();
       }
     }

--- a/test/features/media_details/presentation/widgets/notify_button_test.dart
+++ b/test/features/media_details/presentation/widgets/notify_button_test.dart
@@ -40,6 +40,7 @@ void main() {
     ).thenAnswer((_) async => []);
     when(() => mockRepository.getLikedEntries()).thenAnswer((_) async => []);
     when(() => mockRepository.getNotifiedItems()).thenAnswer((_) async => []);
+    when(() => mockRepository.watchNotifiedItems()).thenAnswer((_) => const Stream.empty());
     when(
       () => mockRepository.toggleNotification(
         any(),

--- a/test/features/search/presentation/providers/search_provider_import_mock_test.dart
+++ b/test/features/search/presentation/providers/search_provider_import_mock_test.dart
@@ -41,6 +41,7 @@ void main() {
     ).thenAnswer((_) async => <repo_types.MediaItemPreview>[]);
     when(() => mock.getCacheSize()).thenAnswer((_) async => 0);
     when(() => mock.getSeenDbSize()).thenAnswer((_) async => 0);
+    when(() => mock.watchNotifiedItems()).thenAnswer((_) => const Stream.empty());
 
     provider = SearchProvider(mock);
   });

--- a/test/helpers/mocks.dart
+++ b/test/helpers/mocks.dart
@@ -105,6 +105,16 @@ class MockMediaRepository extends Mock implements MediaRepository {
       return Future.value();
     }
   }
+
+  @override
+  Stream<void> watchNotifiedItems() {
+    try {
+      return super.noSuchMethod(Invocation.method(#watchNotifiedItems, []))
+          as Stream<void>;
+    } catch (_) {
+      return const Stream.empty();
+    }
+  }
 }
 
 class MockSharedPreferences extends Mock implements SharedPreferences {}


### PR DESCRIPTION
Closes #106 

- Moved notification visibility logic from `NotifyButton` to a new `canBeNotified` getter in the `MediaItem` entity.
- Updated `SearchProvider` to check `canBeNotified` before automatically toggling notifications when adding items to the watchlist.
- Updated `MockMediaRepository` and unit tests to support the new `watchNotifiedItems` stream.
- Simplified `NotifyButton` rendering by utilizing the centralized `canBeNotified` property.