### PR TITLE
feat(search): add TMDB API key requirement check on startup

### DIFF
--- a/lib/features/search/presentation/pages/main_page.dart
+++ b/lib/features/search/presentation/pages/main_page.dart
@@ -11,6 +11,7 @@ import 'package:mediavore/features/media_details/presentation/pages/seen_history
 import 'package:mediavore/features/search/presentation/pages/search_page.dart';
 import 'package:mediavore/features/search/presentation/pages/saved_media_page.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
+import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
 import 'package:provider/provider.dart';
 import 'package:app_links/app_links.dart';
 
@@ -53,6 +54,12 @@ class _MainPageState extends State<MainPage> {
       ) {
         _queueAchievementNotification(achievement);
       });
+
+      // Check if TMDB API key is missing
+      final settings = context.read<SettingsProvider>();
+      if (settings.tmdbApiKey.isEmpty) {
+        _showApiKeyDialog(context, settings);
+      }
     });
   }
 
@@ -239,6 +246,60 @@ class _MainPageState extends State<MainPage> {
         currentIndex: _selectedIndex,
         onTap: _onItemTapped,
       ),
+    );
+  }
+
+  void _showApiKeyDialog(BuildContext context, SettingsProvider settings) {
+    final controller = TextEditingController(text: settings.tmdbApiKey);
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('TMDB API Key Required'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text(
+                'To use this app, you need a TMDB API key. You can get one for free at themoviedb.org.',
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: controller,
+                decoration: const InputDecoration(
+                  hintText: 'Enter your API key here',
+                  border: OutlineInputBorder(),
+                ),
+                obscureText: true,
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.pop(context);
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'You can set your API key later in Settings (accessible from the My Lists, Seen, or Alerts tabs).',
+                      ),
+                      duration: Duration(seconds: 5),
+                    ),
+                  );
+                }
+              },
+              child: const Text('Cancel for now'),
+            ),
+            FilledButton(
+              onPressed: () {
+                settings.setTmdbApiKey(controller.text.trim());
+                Navigator.pop(context);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/test/features/search/presentation/pages/main_page_test.dart
+++ b/test/features/search/presentation/pages/main_page_test.dart
@@ -32,6 +32,7 @@ void main() {
     when(() => mockSharedPreferences.getInt(any())).thenReturn(null);
     when(() => mockSharedPreferences.getDouble(any())).thenReturn(null);
     when(() => mockSharedPreferences.getBool(any())).thenReturn(null);
+    when(() => mockSharedPreferences.getString('tmdbApiKey')).thenReturn('fake_api_key');
 
     when(
       () => mockRepository.getAllListNames(),
@@ -105,6 +106,9 @@ void main() {
     await tester.pumpWidget(createWidgetUnderTest());
     await tester.pumpAndSettle();
 
+    // If API key is empty, dialog shows up. The mock returned a fake key, so there shouldn't be a dialog blocking clicks.
+    // If it *does* happen to show up, we might need to close it. But let's assume it didn't box the tap.
+    
     // Initially on Discover (SearchPage)
     expect(
       find.text('Discover'),
@@ -112,14 +116,14 @@ void main() {
     ); // Tab bar label and AppBar title
 
     // Tap My Lists
-    await tester.tap(find.byIcon(Icons.bookmark));
+    await tester.tap(find.text('My Lists').last);
     await tester.pumpAndSettle();
 
     expect(searchProvider.selectedTab, 1);
     expect(find.text('My Lists'), findsWidgets);
 
     // Tap Seen
-    await tester.tap(find.byIcon(Icons.history));
+    await tester.tap(find.text('Seen').last);
     await tester.pumpAndSettle();
 
     expect(searchProvider.selectedTab, 2);
@@ -132,7 +136,7 @@ void main() {
     await tester.pumpWidget(createWidgetUnderTest());
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byIcon(Icons.bookmark));
+    await tester.tap(find.text('My Lists').last);
     await tester.pumpAndSettle();
 
     expect(searchProvider.selectedTab, 1);


### PR DESCRIPTION
Closes #120

- Implemented a check in `MainPage` to detect if the TMDB API key is missing.
- Added `_showApiKeyDialog` to prompt users for their API key with an option to save or defer.
- Updated `MainPage` tests to mock the API key string in `SharedPreferences` to avoid blocking UI interactions during testing.
- Adjusted widget selectors in tests to use text labels for more reliable tab navigation.