### PR TITLE
feat(background_tasks): implement background sync for returning series using Workmanager

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="fr.zimberts.mediavore">
     <uses-permission android:name="android.permission.INTERNET" />
     <application
@@ -39,6 +40,15 @@
                 <data android:scheme="mediavore" android:host="share" />
             </intent-filter>
         </activity>
+
+        <receiver
+            android:name="dev.fluttercommunity.plus.share.SharePlusPendingIntent"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="dev.fluttercommunity.plus.share.ACTION_READY" />
+            </intent-filter>
+        </receiver>
+
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>13.0</string>
+  <string>14.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '13.0'
+platform :ios, '14.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -108,6 +108,8 @@ PODS:
     - Flutter
     - FlutterMacOS
   - SwiftyGif (5.4.5)
+  - workmanager_apple (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - app_links (from `.symlinks/plugins/app_links/ios`)
@@ -120,6 +122,7 @@ DEPENDENCIES:
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
+  - workmanager_apple (from `.symlinks/plugins/workmanager_apple/ios`)
 
 SPEC REPOS:
   trunk:
@@ -161,6 +164,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
     :path: ".symlinks/plugins/sqflite_darwin/darwin"
+  workmanager_apple:
+    :path: ".symlinks/plugins/workmanager_apple/ios"
 
 SPEC CHECKSUMS:
   app_links: 3dbc685f76b1693c66a6d9dd1e9ab6f73d97dc0a
@@ -189,7 +194,8 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   SwiftyGif: 706c60cf65fa2bc5ee0313beece843c8eb8194d4
+  workmanager_apple: 904529ae31e97fc5be632cf628507652294a0778
 
-PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865
 
 COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -472,10 +472,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -490,6 +490,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = E5L7NC8M9T;
 				ENABLE_BITCODE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -497,8 +498,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -602,10 +605,11 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -653,10 +657,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -673,6 +677,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = E5L7NC8M9T;
 				ENABLE_BITCODE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -680,9 +685,11 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -696,6 +703,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = E5L7NC8M9T;
 				ENABLE_BITCODE = NO;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -703,8 +711,10 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = fr.zimberts.mediavore;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,18 +1,22 @@
 import Flutter
 import UIKit
-import workmanager
+import workmanager_apple
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
+  private let periodicSyncTaskIdentifier = "fr.zimberts.mediavore.dailySync"
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
-    
-    // Register Workmanager for background tasks
-    WorkmanagerPlugin.registerTask(withIdentifier: "dailySync")
-    WorkmanagerPlugin.registerTask(withIdentifier: "refreshReturningSeries")
+
+    // Register the periodic BGTaskScheduler identifier used by Workmanager on iOS.
+    WorkmanagerPlugin.registerPeriodicTask(
+      withIdentifier: periodicSyncTaskIdentifier,
+      frequency: NSNumber(value: 24 * 60 * 60)
+    )
     
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import workmanager
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,11 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    
+    // Register Workmanager for background tasks
+    WorkmanagerPlugin.registerTask(withIdentifier: "dailySync")
+    WorkmanagerPlugin.registerTask(withIdentifier: "refreshReturningSeries")
+    
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -30,6 +30,15 @@
 		<string>MediaVore needs access to the photo library to share or attach media.</string>
 		<key>NSPhotoLibraryAddUsageDescription</key>
 		<string>MediaVore needs permission to save images to your library.</string>
+		<key>UIBackgroundModes</key>
+		<array>
+			<string>fetch</string>
+			<string>processing</string>
+		</array>
+		<key>BGTaskSchedulerPermittedIdentifiers</key>
+		<array>
+			<string>fr.zimberts.mediavore.dailySync</string>
+		</array>
 		<key>UILaunchStoryboardName</key>
 		<string>LaunchScreen</string>
 		<key>UIMainStoryboardFile</key>

--- a/lib/core/cache/media_cache.dart
+++ b/lib/core/cache/media_cache.dart
@@ -270,4 +270,12 @@ class MediaCache {
       _detailsCache.containsKey(_getKey(id, type));
   bool isSeasonCached(int tvId, int seasonNumber) =>
       _seasonCache.containsKey(_getSeasonKey(tvId, seasonNumber));
+
+  DateTime? getCacheUpdateDate(int tmdbId, MediaType type) {
+    final cachedRecord = _isar.cachedMedias
+        .where()
+        .tmdbIdTypeEqualTo(tmdbId, type.name)
+        .findFirstSync();
+    return cachedRecord?.updatedAt;
+  }
 }

--- a/lib/core/services/background_task_service.dart
+++ b/lib/core/services/background_task_service.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/foundation.dart';
+import 'package:workmanager/workmanager.dart';
+import 'package:mediavore/core/di/injection.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/core/di/injection.config.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+const fetchTask = "dailySync";
+const refreshReturningSeriesTask = "refreshReturningSeries";
+
+@pragma('vm:entry-point')
+void callbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    try {
+      debugPrint("Native called background task: $task");
+      
+      // Initialize full DI safely so we can use locator<MediaRepository>() 
+      // It includes opening Isar gracefully.
+      await init(locator);
+      final repo = locator<MediaRepository>();
+
+      if (task == fetchTask) {
+        debugPrint("Running daily background sync...");
+        final seenItems = await repo.getSeenItems();
+        
+        final Map<int, List> tvWatches = {};
+        for (var item in seenItems) {
+          if (item.type.name == 'tv') { // MediaType.tv
+            tvWatches.putIfAbsent(item.tmdbId, () => []).add(item);
+          }
+        }
+
+        for (final entry in tvWatches.entries) {
+          final tmdbId = entry.key;
+          final watches = entry.value;
+
+          int maxSeason = 0;
+          int maxEpisode = 0;
+          for (var w in watches) {
+            final s = w.seasonNumber ?? 0;
+            final e = w.episodeNumber ?? 0;
+            if (s > maxSeason) {
+              maxSeason = s;
+              maxEpisode = e;
+            } else if (s == maxSeason && e > maxEpisode) {
+              maxEpisode = e;
+            }
+          }
+
+          try {
+            final details = await repo.getMediaDetails(tmdbId, type: MediaType.values.firstWhere((t) => t.name == 'tv'));
+            final mediaItem = details.item;
+            
+            final isReturning = mediaItem.status?.toLowerCase() == 'returning series';
+            final isLastEpisode = mediaItem.lastSeasonNumber == maxSeason && mediaItem.lastEpisodeNumber == maxEpisode;
+
+            if (isReturning && isLastEpisode) {
+              final cacheDate = await repo.getCacheUpdateDate(tmdbId, MediaType.values.firstWhere((t) => t.name == 'tv'));
+              if (cacheDate == null) continue;
+
+              final age = DateTime.now().difference(cacheDate).inDays;
+              bool shouldUpdate = false;
+
+              if (age > 7) {
+                if (mediaItem.lastEpisodeAirDate != null && mediaItem.lastEpisodeAirDate!.isNotEmpty) {
+                  try {
+                    final lastAir = DateTime.parse(mediaItem.lastEpisodeAirDate!);
+                    if (lastAir.weekday == DateTime.now().weekday) {
+                      shouldUpdate = true;
+                    }
+                  } catch (_) {}
+                }
+              } else if (age >= 1) {
+                shouldUpdate = true;
+              }
+
+              if (shouldUpdate) {
+                debugPrint("Daily sync refreshing returning series: $tmdbId");
+                await repo.refreshReturningSeries(tmdbId);
+              }
+            }
+          } catch (_) {}
+        }
+      } else if (task == refreshReturningSeriesTask) {
+        final int? id = inputData?['tmdbId'];
+        if (id != null) {
+          debugPrint("Running 1-off refresh for series ID: $id...");
+          await repo.refreshReturningSeries(id);
+        }
+      }
+      return Future.value(true);
+    } catch (err, stack) {
+      debugPrint("Background Task Failed: $err");
+      debugPrint(stack.toString());
+      return Future.value(false); // return false on failure
+    }
+  });
+}
+
+class BackgroundTaskService {
+  static void initialize() {
+    Workmanager().initialize(
+      callbackDispatcher,
+    );
+  }
+
+  static void registerDailySync() {
+    Workmanager().registerPeriodicTask(
+      "1", // Unique ID
+      fetchTask,
+      frequency: const Duration(days: 1),
+      constraints: Constraints(
+        networkType: NetworkType.connected, // Only run on wifi/data
+      ),
+    );
+  }
+
+  static void dispatchOneOffRefresh(int tmdbId) {
+    Workmanager().registerOneOffTask(
+      "refresh_${tmdbId}_${DateTime.now().millisecondsSinceEpoch}", // Unique ID
+      refreshReturningSeriesTask,
+      inputData: {"tmdbId": tmdbId},
+      constraints: Constraints(
+        networkType: NetworkType.connected,
+      ),
+    );
+  }
+}

--- a/lib/core/services/background_task_service.dart
+++ b/lib/core/services/background_task_service.dart
@@ -6,7 +6,9 @@ import 'package:mediavore/core/di/injection.config.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 
 const fetchTask = "dailySync";
+const fetchTaskIdentifier = "fr.zimberts.mediavore.dailySync";
 const refreshReturningSeriesTask = "refreshReturningSeries";
+const refreshReturningSeriesPrefix = "refresh_";
 
 @pragma('vm:entry-point')
 void callbackDispatcher() {
@@ -19,7 +21,7 @@ void callbackDispatcher() {
       await init(locator);
       final repo = locator<MediaRepository>();
 
-      if (task == fetchTask) {
+      if (task == fetchTask || task == fetchTaskIdentifier || task == Workmanager.iOSBackgroundTask) {
         debugPrint("Running daily background sync...");
         final seenItems = await repo.getSeenItems();
         
@@ -81,7 +83,7 @@ void callbackDispatcher() {
             }
           } catch (_) {}
         }
-      } else if (task == refreshReturningSeriesTask) {
+      } else if (task == refreshReturningSeriesTask || task.startsWith(refreshReturningSeriesPrefix)) {
         final int? id = inputData?['tmdbId'];
         if (id != null) {
           debugPrint("Running 1-off refresh for series ID: $id...");
@@ -106,7 +108,7 @@ class BackgroundTaskService {
 
   static void registerDailySync() {
     Workmanager().registerPeriodicTask(
-      "1", // Unique ID
+      fetchTaskIdentifier,
       fetchTask,
       frequency: const Duration(days: 1),
       constraints: Constraints(

--- a/lib/features/search/data/datasources/media_remote_data_source.dart
+++ b/lib/features/search/data/datasources/media_remote_data_source.dart
@@ -12,12 +12,50 @@ class MediaRemoteDataSource {
   final Dio dio;
   final SharedPreferences prefs;
 
-  String get _apiToken => prefs.getString('tmdbApiKey') ?? '';
+  String get _apiCredential {
+    final raw = (prefs.getString('tmdbApiKey') ?? '').trim();
+    if (raw.toLowerCase().startsWith('bearer ')) {
+      return raw.substring(7).trim();
+    }
+    return raw;
+  }
+
+  bool _isV3ApiKey(String credential) =>
+      RegExp(r'^[a-fA-F0-9]{32}$').hasMatch(credential);
+
+  Future<Response<dynamic>> _tmdbGet(
+    String url, {
+    Map<String, dynamic>? queryParameters,
+  }) {
+    final credential = _apiCredential;
+    if (credential.isEmpty) {
+      throw const ConfigurationException(
+        'TMDB API credential is missing. Add a v3 API key or v4 read token in Settings.',
+      );
+    }
+
+    final params = <String, dynamic>{...?queryParameters};
+    final useV3ApiKey = _isV3ApiKey(credential);
+
+    if (useV3ApiKey) {
+      params['api_key'] = credential;
+    }
+
+    final options = useV3ApiKey
+        ? null
+        : Options(headers: {'Authorization': 'Bearer $credential'});
+
+    return dio.get(
+      url,
+      queryParameters: params.isEmpty ? null : params,
+      options: options,
+    );
+  }
 
   /// Creates a new instance of [MediaRemoteDataSource].
   ///
-  /// Requires a [Dio] to make network requests and an [apiToken] for TMDB API.
-  /// If [apiToken] is not provided, it will be read from the environment variable 'TMDB_API_TOKEN'.
+  /// Requires a [Dio] to make network requests and [SharedPreferences]
+  /// that stores the TMDB credential under 'tmdbApiKey'.
   @factoryMethod
   factory MediaRemoteDataSource({required Dio dio, required SharedPreferences prefs}) {
     return MediaRemoteDataSource._internal(
@@ -55,10 +93,9 @@ class MediaRemoteDataSource {
       if (language != null) params['language'] = language;
 
       debugPrint('[Remote] searchMedia -> /search/$path params=$params');
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/search/$path',
         queryParameters: params,
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
 
       final List results = response.data['results'];
@@ -97,6 +134,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to load results', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse search response', e);
     }
   }
@@ -108,10 +146,7 @@ class MediaRemoteDataSource {
   }) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
-        'https://api.themoviedb.org/3/$path/$id',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
-      );
+      final response = await _tmdbGet('https://api.themoviedb.org/3/$path/$id');
       final data = Map<String, dynamic>.from(response.data);
       data['media_type'] = path;
       return MediaItem.fromJson(data);
@@ -132,6 +167,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to load details', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse response', e);
     }
   }
@@ -142,9 +178,8 @@ class MediaRemoteDataSource {
     int seasonNumber,
   ) async {
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/tv/$tvId/season/$seasonNumber',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data;
     } on DioException catch (e) {
@@ -154,6 +189,7 @@ class MediaRemoteDataSource {
         e,
       );
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse season details', e);
     }
   }
@@ -165,9 +201,8 @@ class MediaRemoteDataSource {
   }) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/$path/$id/credits',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data;
     } on DioException catch (e) {
@@ -187,6 +222,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to load credits', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse credits response', e);
     }
   }
@@ -194,10 +230,7 @@ class MediaRemoteDataSource {
   /// Fetches the details for an actor from the TMDB API.
   Future<ActorDetails> getActorDetails(int actorId) async {
     try {
-      final response = await dio.get(
-        'https://api.themoviedb.org/3/person/$actorId',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
-      );
+      final response = await _tmdbGet('https://api.themoviedb.org/3/person/$actorId');
       return ActorDetails.fromJson(response.data);
     } on DioException catch (e) {
       switch (e.type) {
@@ -219,6 +252,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to load actor details', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse actor details response', e);
     }
   }
@@ -249,10 +283,9 @@ class MediaRemoteDataSource {
       if (minRating != null) params['vote_average.gte'] = minRating;
       if (language != null) params['language'] = language;
 
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/discover/$path',
         queryParameters: params,
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
 
       final List results = response.data['results'];
@@ -297,6 +330,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to discover', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse discover response', e);
     }
   }
@@ -304,9 +338,8 @@ class MediaRemoteDataSource {
   /// Fetches the movies an actor has been in.
   Future<List<MediaItem>> getActorMediaCredits(int actorId) async {
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/person/$actorId/combined_credits',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['cast'];
       return results.map((m) => MediaItem.fromJson(m)).toList();
@@ -330,6 +363,7 @@ class MediaRemoteDataSource {
           throw ServerException('Failed to load actor movie credits', null, e);
       }
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to parse actor movie credits response', e);
     }
   }
@@ -361,10 +395,7 @@ class MediaRemoteDataSource {
   Future<List<MediaItem>> getSimilarMedia(int id, MediaType type) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
-        'https://api.themoviedb.org/3/$path/$id/similar',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
-      );
+      final response = await _tmdbGet('https://api.themoviedb.org/3/$path/$id/similar');
       final List results = response.data['results'];
       return results.map((m) {
         final data = Map<String, dynamic>.from(m);
@@ -372,6 +403,7 @@ class MediaRemoteDataSource {
         return MediaItem.fromJson(data);
       }).toList();
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to fetch similar media', e);
     }
   }
@@ -379,9 +411,8 @@ class MediaRemoteDataSource {
   /// Fetches the parts of a collection (saga) by collection id.
   Future<List<MediaItem>> getCollectionParts(int collectionId) async {
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/collection/$collectionId',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['parts'] ?? [];
       return results.map((m) {
@@ -390,6 +421,7 @@ class MediaRemoteDataSource {
         return MediaItem.fromJson(data);
       }).toList();
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to fetch collection parts', e);
     }
   }
@@ -397,9 +429,8 @@ class MediaRemoteDataSource {
   Future<List<MediaItem>> getRecommendedMedia(int id, MediaType type) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/$path/$id/recommendations',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       final List results = response.data['results'];
       return results.map((m) {
@@ -408,6 +439,7 @@ class MediaRemoteDataSource {
         return MediaItem.fromJson(data);
       }).toList();
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to fetch recommendations', e);
     }
   }
@@ -415,12 +447,12 @@ class MediaRemoteDataSource {
   Future<Map<String, dynamic>> getWatchProviders(int id, MediaType type) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
+      final response = await _tmdbGet(
         'https://api.themoviedb.org/3/$path/$id/watch/providers',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
       );
       return response.data['results'] as Map<String, dynamic>;
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to fetch watch providers', e);
     }
   }
@@ -428,13 +460,11 @@ class MediaRemoteDataSource {
   Future<List<Map<String, dynamic>>> getVideos(int id, MediaType type) async {
     final path = type == MediaType.tv ? 'tv' : 'movie';
     try {
-      final response = await dio.get(
-        'https://api.themoviedb.org/3/$path/$id/videos',
-        options: Options(headers: {'Authorization': 'Bearer $_apiToken'}),
-      );
+      final response = await _tmdbGet('https://api.themoviedb.org/3/$path/$id/videos');
       final List results = response.data['results'];
       return results.cast<Map<String, dynamic>>();
     } catch (e) {
+      if (e is AppException) rethrow;
       throw ParsingException('Failed to fetch videos', e);
     }
   }

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -647,14 +647,18 @@ class MediaRepositoryImpl implements MediaRepository {
                 }
 
                 final airDateStr = ep['air_date'] as String?;
-                if (airDateStr != null) {
-                  try {
-                    final ad = DateTime.parse(airDateStr);
-                    if (ad.isAfter(DateTime.now())) {
-                      continue;
-                    }
-                    foundAirDate = ad;
-                  } catch (_) {}
+                if (airDateStr == null || airDateStr.isEmpty) {
+                  continue;
+                }
+
+                try {
+                  final ad = DateTime.parse(airDateStr);
+                  if (ad.isAfter(DateTime.now())) {
+                    continue;
+                  }
+                  foundAirDate = ad;
+                } catch (_) {
+                  continue;
                 }
 
                 foundSeason = season.seasonNumber;
@@ -1245,6 +1249,66 @@ class MediaRepositoryImpl implements MediaRepository {
   }
 
   @override
+  Future<void> refreshReturningSeries(int tmdbId) async {
+    await _ensureInitialized();
+    try {
+      final type = MediaType.tv;
+
+      // 1. Fetch TV details
+      final itemFuture = remoteDataSource.getMediaItem(tmdbId, type: type);
+      final creditsFuture = remoteDataSource.getMediaCredits(tmdbId, type: type);
+      final similarFuture = remoteDataSource.getSimilarMedia(tmdbId, type);
+      final recommendationsFuture = remoteDataSource.getRecommendedMedia(tmdbId, type);
+      final watchProvidersFuture = remoteDataSource.getWatchProviders(tmdbId, type);
+      final videosFuture = remoteDataSource.getVideos(tmdbId, type);
+
+      final item = await itemFuture;
+
+      Map<String, dynamic> credits = {'cast': [], 'crew': []};
+      try { credits = await creditsFuture; } catch (_) {}
+
+      final List castResults = credits['cast'] ?? [];
+      final List crewResults = credits['crew'] ?? [];
+      final List<CastMember> cast = castResults.map((c) => CastMember.fromJson(c)).toList();
+      final CrewMember? director = crewResults.firstWhere(
+        (c) => c['job'] == 'Director',
+        orElse: () => null,
+      ) != null ? CrewMember.fromJson(crewResults.firstWhere((c) => c['job'] == 'Director')) : null;
+
+      final similar = await similarFuture;
+      final recommendations = await recommendationsFuture;
+      final watchProviders = await watchProvidersFuture;
+      final videos = await videosFuture;
+
+      final details = MediaDetails(
+        item: item,
+        cast: cast,
+        director: director,
+        similar: similar,
+        recommendations: recommendations,
+        watchProviders: watchProviders,
+        videos: videos,
+      );
+
+      // Overwrite the cache
+      await cache.cacheItem(item);
+      await cache.cacheDetails(details);
+
+      // 2. Fetch latest season
+      final lastSeasonNum = item.numberOfSeasons;
+      if (lastSeasonNum != null && lastSeasonNum > 0) {
+        final seasonDetails = await remoteDataSource.getSeasonDetails(tmdbId, lastSeasonNum);
+        await cache.cacheSeason(tmdbId, lastSeasonNum, seasonDetails);
+      }
+      
+      // 3. Update Quick Add logic to pick up new episodes
+      await populateQuickAddFromSeenHistory(tmdbId: tmdbId);
+    } catch (e) {
+      debugPrint("Failed to refresh returning series $tmdbId: $e");
+    }
+  }
+
+  @override
   Future<void> addQuickAddItem(QuickAddItem item) async {
     await _ensureInitialized();
     final model = QuickAddItemModel(
@@ -1407,15 +1471,19 @@ class MediaRepositoryImpl implements MediaRepository {
                   }
 
                   final airDateStr = ep['air_date'] as String?;
-                  if (airDateStr != null) {
-                    try {
-                      final ad = DateTime.parse(airDateStr);
-                      if (ad.isAfter(DateTime.now())) {
-                        // skip future episodes
-                        continue;
-                      }
-                      foundAirDate = ad;
-                    } catch (_) {}
+                  if (airDateStr == null || airDateStr.isEmpty) {
+                    continue;
+                  }
+
+                  try {
+                    final ad = DateTime.parse(airDateStr);
+                    if (ad.isAfter(DateTime.now())) {
+                      // skip future episodes
+                      continue;
+                    }
+                    foundAirDate = ad;
+                  } catch (_) {
+                    continue;
                   }
 
                   foundSeason = season.seasonNumber;
@@ -1464,5 +1532,11 @@ class MediaRepositoryImpl implements MediaRepository {
   Future<void> clearQuickAddItems() async {
     await _ensureInitialized();
     return localDataSource.clearQuickAddItems();
+  }
+
+  @override
+  Future<DateTime?> getCacheUpdateDate(int tmdbId, MediaType type) async {
+    await _ensureInitialized();
+    return cache.getCacheUpdateDate(tmdbId, type);
   }
 }

--- a/lib/features/search/domain/repositories/media_repository.dart
+++ b/lib/features/search/domain/repositories/media_repository.dart
@@ -170,6 +170,12 @@ abstract class MediaRepository {
   /// QuickAdd: returns current quick-add entries (next episodes the user can quickly mark seen)
   Future<List<QuickAddItem>> getQuickAddItems();
 
+  /// Refreshes a Returning Series specifically for background syncing
+  Future<void> refreshReturningSeries(int tmdbId);
+
+  /// Gets the last cache update date for a specific media item.
+  Future<DateTime?> getCacheUpdateDate(int tmdbId, MediaType type);
+
   /// Removes a quick-add entry by its isar id.
   Future<void> removeQuickAddItemById(int isarId);
 

--- a/lib/features/search/presentation/pages/main_page.dart
+++ b/lib/features/search/presentation/pages/main_page.dart
@@ -255,18 +255,18 @@ class _MainPageState extends State<MainPage> {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('TMDB API Key Required'),
+          title: const Text('TMDB Credential Required'),
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
               const Text(
-                'To use this app, you need a TMDB API key. You can get one for free at themoviedb.org.',
+                'To use this app, you need a TMDB credential (v3 API key or v4 read token). You can get one at themoviedb.org.',
               ),
               const SizedBox(height: 16),
               TextField(
                 controller: controller,
                 decoration: const InputDecoration(
-                  hintText: 'Enter your API key here',
+                  hintText: 'Enter TMDB v3 API key or v4 read token',
                   border: OutlineInputBorder(),
                 ),
                 obscureText: true,

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/media_details.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
+import 'package:mediavore/core/services/background_task_service.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 
 class SearchProvider with ChangeNotifier {
@@ -667,6 +668,21 @@ class SearchProvider with ChangeNotifier {
                 mediaItem.lastEpisodeNumber != null &&
                 mediaItem.lastSeasonNumber == item.seasonNumber &&
                 mediaItem.lastEpisodeNumber == item.episodeNumber;
+
+            // Trigger background sync if they just watched the last episode of a returning series
+            // and the cache is older than 2 days.
+            if (isLastEpisode && 
+                mediaItem.status != null && 
+                mediaItem.status!.toLowerCase() == 'returning series') {
+              final cacheDate = await repository.getCacheUpdateDate(item.tmdbId, MediaType.tv);
+              if (cacheDate == null || DateTime.now().difference(cacheDate).inDays >= 2) {
+                try {
+                  BackgroundTaskService.dispatchOneOffRefresh(item.tmdbId);
+                } catch (e) {
+                  debugPrint('Failed to dispatch background task: $e');
+                }
+              }
+            }
 
             bool noNext = false;
             try {

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -168,7 +168,7 @@ class SettingsPage extends StatelessWidget {
           const _SectionHeader(title: 'API Configuration'),
           ListTile(
             leading: const Icon(Icons.key),
-            title: const Text('TMDB API Key'),
+            title: const Text('TMDB API Credential'),
             subtitle: Text(
               settings.tmdbApiKey.isEmpty
                   ? 'Not set'
@@ -209,11 +209,11 @@ class SettingsPage extends StatelessWidget {
       context: context,
       builder: (context) {
         return AlertDialog(
-          title: const Text('TMDB API Key'),
+          title: const Text('TMDB API Credential'),
           content: TextField(
             controller: controller,
             decoration: const InputDecoration(
-              hintText: 'Enter your API key here',
+              hintText: 'Enter TMDB v3 API key or v4 read token',
               border: OutlineInputBorder(),
             ),
             obscureText: true,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:mediavore/core/di/injection.dart';
 import 'package:mediavore/core/di/injection.config.dart';
 import 'package:mediavore/features/achievements/presentation/providers/achievement_provider.dart';
 import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+import 'package:mediavore/core/services/background_task_service.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
 import 'package:provider/provider.dart';
@@ -12,33 +13,94 @@ import 'features/search/presentation/pages/main_page.dart';
 Future<void> main() async {
   debugPrint('--- App Starting ---');
   WidgetsFlutterBinding.ensureInitialized();
+  runApp(const BootstrapperApp());
+}
 
-  try {
-    // DefinitionsLoader should be provided by generated DI (injection.config.dart).
-    // Avoid manual registration here; run codegen to ensure it's registered.
+class BootstrapperApp extends StatefulWidget {
+  const BootstrapperApp({super.key});
 
-    await init(locator);
-    runApp(const MediaVoreApp());
-  } catch (e, stackTrace) {
-    debugPrint('Fatal error during initialization: $e');
-    debugPrint(stackTrace.toString());
+  @override
+  State<BootstrapperApp> createState() => _BootstrapperAppState();
+}
 
-    runApp(
-      MaterialApp(
+class _BootstrapperAppState extends State<BootstrapperApp> {
+  bool _isInit = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    // Allow the first frame to paint the spinner BEFORE starting any heavy init
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeApp();
+    });
+  }
+
+  Future<void> _initializeApp() async {
+    try {
+      // Yield slightly time for the UI thread to push the frame
+      await Future.delayed(const Duration(milliseconds: 250));
+
+      await init(locator);
+      
+      // Setup Background Tasks (safe to call after isar is opened by locator)
+      if (Theme.of(context).platform == TargetPlatform.android || Theme.of(context).platform == TargetPlatform.iOS) {
+        try {
+          BackgroundTaskService.initialize();
+          BackgroundTaskService.registerDailySync();
+        } catch (e) {
+          debugPrint('Failed to init workmanager $e');
+        }
+      }
+
+      if (mounted) setState(() => _isInit = true);
+    } catch (e, stackTrace) {
+      debugPrint('Fatal error during initialization: $e');
+      debugPrint(stackTrace.toString());
+      if (mounted) setState(() => _error = e.toString());
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return MaterialApp(
         home: Scaffold(
           body: Center(
             child: Padding(
               padding: const EdgeInsets.all(24.0),
               child: Text(
-                'Failed to start app:\n$e',
+                'Failed to start app:\n$_error',
                 textAlign: TextAlign.center,
                 style: const TextStyle(color: Colors.red),
               ),
             ),
           ),
         ),
-      ),
-    );
+      );
+    }
+
+    if (!_isInit) {
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(brightness: Brightness.dark),
+        home: const Scaffold(
+          backgroundColor: Colors.black,
+          body: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                CircularProgressIndicator(color: Colors.white),
+                SizedBox(height: 16),
+                Text('Loading MediaVore...', style: TextStyle(color: Colors.white)),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return const MediaVoreApp();
   }
 }
 

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,67 @@
+PODS:
+  - app_links (6.4.1):
+    - FlutterMacOS
+  - file_picker (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - isar_flutter_libs (1.0.0):
+    - FlutterMacOS
+  - mobile_scanner (5.2.3):
+    - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - share_plus (0.0.1):
+    - FlutterMacOS
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
+  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - isar_flutter_libs (from `Flutter/ephemeral/.symlinks/plugins/isar_flutter_libs/macos`)
+  - mobile_scanner (from `Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
+
+EXTERNAL SOURCES:
+  app_links:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
+  file_picker:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  isar_flutter_libs:
+    :path: Flutter/ephemeral/.symlinks/plugins/isar_flutter_libs/macos
+  mobile_scanner:
+    :path: Flutter/ephemeral/.symlinks/plugins/mobile_scanner/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  share_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sqflite_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
+
+SPEC CHECKSUMS:
+  app_links: 05a6ec2341985eb05e9f97dc63f5837c39895c3f
+  file_picker: 7584aae6fa07a041af2b36a2655122d42f578c1a
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  isar_flutter_libs: a65381780401f81ad6bf3f2e7cd0de5698fb98c4
+  mobile_scanner: bd1e7cd9b67b442f4d903747f4778e040513f860
+  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
+  share_plus: 510bf0af1a42cd602274b4629920c9649c52f4cc
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+
+PODFILE CHECKSUM: 54d867c82ac51cbd61b565781b9fada492027009
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -21,12 +21,14 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2DA8E012F296E65DE435B958 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30325C7C450C7225F98F842A /* Pods_RunnerTests.framework */; };
 		331C80D8294CF71000263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C80D7294CF71000263BE5 /* RunnerTests.swift */; };
 		335BBD1B22A9A15E00E9071D /* GeneratedPluginRegistrant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */; };
 		33CC10F12044A3C60003C045 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC10F02044A3C60003C045 /* AppDelegate.swift */; };
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		3640CC968866A4376A607575 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7A20FA809A46525EFF3A4D31 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,11 +62,13 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0CA268315A5EC161DF596CE6 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		30325C7C450C7225F98F842A /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GeneratedPluginRegistrant.swift; sourceTree = "<group>"; };
-		33CC10ED2044A3C60003C045 /* mediavore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "mediavore.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33CC10ED2044A3C60003C045 /* mediavore.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = mediavore.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		33CC10F02044A3C60003C045 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		33CC10F22044A3C60003C045 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Runner/Assets.xcassets; sourceTree = "<group>"; };
 		33CC10F52044A3C60003C045 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
@@ -76,8 +80,14 @@
 		33E51913231747F40026EE4D /* DebugProfile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DebugProfile.entitlements; sourceTree = "<group>"; };
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
+		48DF747D3325BC8A46641B7B /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
+		7A20FA809A46525EFF3A4D31 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		7B013D9667D03FF8588A8873 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		9A6F60358874F29D9415AD22 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		B6C645CD2F65DB367F818CED /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		BEA44739029D369959B47E47 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2DA8E012F296E65DE435B958 /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -92,6 +103,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3640CC968866A4376A607575 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -125,6 +137,7 @@
 				331C80D6294CF71000263BE5 /* RunnerTests */,
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
+				48A649F7C53C24ED2F1BB6BC /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -172,9 +185,25 @@
 			path = Runner;
 			sourceTree = "<group>";
 		};
+		48A649F7C53C24ED2F1BB6BC /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0CA268315A5EC161DF596CE6 /* Pods-Runner.debug.xcconfig */,
+				B6C645CD2F65DB367F818CED /* Pods-Runner.release.xcconfig */,
+				BEA44739029D369959B47E47 /* Pods-Runner.profile.xcconfig */,
+				7B013D9667D03FF8588A8873 /* Pods-RunnerTests.debug.xcconfig */,
+				48DF747D3325BC8A46641B7B /* Pods-RunnerTests.release.xcconfig */,
+				9A6F60358874F29D9415AD22 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				7A20FA809A46525EFF3A4D31 /* Pods_Runner.framework */,
+				30325C7C450C7225F98F842A /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -186,6 +215,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				4236E9A7F6B4B13D50BFCD76 /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -204,11 +234,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				E2FE8AD96DF9DF96CE77C14C /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				D008698F254E00AED7F5084C /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -329,6 +361,67 @@
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
 		};
+		4236E9A7F6B4B13D50BFCD76 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D008698F254E00AED7F5084C /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E2FE8AD96DF9DF96CE77C14C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -380,6 +473,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7B013D9667D03FF8588A8873 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -394,6 +488,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 48DF747D3325BC8A46641B7B /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -408,6 +503,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A6F60358874F29D9415AD22 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1181,6 +1181,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  workmanager:
+    dependency: "direct main"
+    description:
+      name: workmanager
+      sha256: "065673b2a465865183093806925419d311a9a5e0995aa74ccf8920fd695e2d10"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+3"
+  workmanager_android:
+    dependency: transitive
+    description:
+      name: workmanager_android
+      sha256: "9ae744db4ef891f5fcd2fb8671fccc712f4f96489a487a1411e0c8675e5e8cb7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.0+2"
+  workmanager_apple:
+    dependency: transitive
+    description:
+      name: workmanager_apple
+      sha256: "1cc12ae3cbf5535e72f7ba4fde0c12dd11b757caf493a28e22d684052701f2ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+2"
+  workmanager_platform_interface:
+    dependency: transitive
+    description:
+      name: workmanager_platform_interface
+      sha256: f40422f10b970c67abb84230b44da22b075147637532ac501729256fcea10a47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1+1"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   rxdart: ^0.27.7
   archive: ^4.0.9
   csv: ^7.2.0
+  workmanager: ^0.9.0+3
 
 dev_dependencies:
   flutter_test:

--- a/test/features/search/data/repositories/populate_quickadd_unaired_episode_test.dart
+++ b/test/features/search/data/repositories/populate_quickadd_unaired_episode_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mediavore/features/search/data/repositories/media_repository_impl.dart';
+import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/core/domain/entities/seen_item.dart';
+
+import '../../../../helpers/mocks.dart';
+
+void main() {
+  late MockMediaListLocalDataSource local;
+  late MockMediaRemoteDataSource remote;
+  late MockMediaCache cache;
+  late MediaRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(SeenItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      title: 'f',
+      seenDate: DateTime.now(),
+    ));
+    registerFallbackValue(QuickAddItemModel(
+      tmdbId: 1,
+      type: 'tv',
+      insertedAt: DateTime.now(),
+    ));
+    registerFallbackValue(FakeMediaItem());
+  });
+
+  setUp(() {
+    local = MockMediaListLocalDataSource();
+    remote = MockMediaRemoteDataSource();
+    cache = MockMediaCache();
+
+    repository = MediaRepositoryImpl(
+      remoteDataSource: remote,
+      localDataSource: local,
+      cache: cache,
+      autoInit: false,
+    );
+  });
+
+  test('future and unaired episodes are skipped in quick add population', () async {
+    final tmdbId = 300;
+
+    final now = DateTime.now();
+    // Watch up to episode 16
+    final seenItems = List.generate(
+      16,
+      (i) => SeenItemModel(
+        tmdbId: tmdbId,
+        type: 'tv',
+        title: 'T',
+        seenDate: now.subtract(Duration(days: 16 - i)),
+        seasonNumber: 1,
+        episodeNumber: i + 1,
+      ),
+    );
+
+    when(() => local.getAllSeenItems()).thenAnswer((_) async => seenItems);
+    when(() => local.getQuickAddItems()).thenAnswer((_) async => <QuickAddItemModel>[]);
+    when(() => local.isOptedOut(any(), seasonNumber: any(named: 'seasonNumber'), episodeNumber: any(named: 'episodeNumber')))
+        .thenAnswer((_) async => false);
+    when(() => local.getSeenStatus(tmdbId, 'tv')).thenAnswer((_) async => seenItems);
+
+    final media = MediaItem(
+      id: tmdbId,
+      title: 'T',
+      overview: '',
+      releaseDate: '2020-01-01',
+      seasons: [
+        TVSeason(id: 1, seasonNumber: 1, episodeCount: 18),
+      ],
+    );
+
+    when(() => cache.getItem(tmdbId, MediaType.tv)).thenReturn(null);
+    when(() => remote.getMediaItem(tmdbId, type: MediaType.tv)).thenAnswer((_) async => media);
+
+    when(() => cache.cacheItem(any())).thenAnswer((_) async {});
+    when(() => cache.isSeasonCached(any(), any())).thenReturn(false);
+    when(() => cache.cacheSeason(any(), any(), any())).thenAnswer((_) async {});
+    when(() => cache.getSeason(any(), any())).thenReturn(null);
+
+    // Provide episode info logic
+    when(() => remote.getSeasonDetails(tmdbId, 1)).thenAnswer((_) async => {
+          'episodes': List.generate(18, (i) {
+            final epNum = i + 1;
+            String? airDate;
+
+            if (epNum <= 16) {
+              // Past episodes
+              airDate = now.subtract(Duration(days: 30 - i)).toIso8601String().substring(0, 10);
+            } else if (epNum == 17) {
+              // Future episode
+              airDate = now.add(Duration(days: 7)).toIso8601String().substring(0, 10);
+            } else if (epNum == 18) {
+              // Unaired (null)
+              airDate = null;
+            }
+
+            return {
+              'episode_number': epNum,
+              'air_date': airDate,
+            };
+          }),
+        });
+
+    final added = <QuickAddItemModel>[];
+    when(() => local.addQuickAddItem(any())).thenAnswer((inv) async {
+      final arg = inv.positionalArguments[0] as QuickAddItemModel;
+      added.add(arg);
+    });
+
+    await repository.populateQuickAddFromSeenHistory();
+
+    // Since episode 17 is in the future, and 18 has no air date, 
+    // the system should NOT add any to quick add since the next available episode hasn't aired yet.
+    expect(added.isEmpty, isTrue, reason: "Expected 0 quick-adds because ep 17 is future and ep 18 is unaired");
+  });
+
+  test('markAsSeen also skips future and unaired episodes when computing next quick add', () async {
+    final tmdbId = 300;
+    final now = DateTime.now();
+    
+    // Simulate marking episode 16 as seen
+    final item = SeenItem(
+      id: 1,
+      tmdbId: tmdbId,
+      type: MediaType.tv,
+      title: 'T',
+      seenDate: now,
+      seasonNumber: 1,
+      episodeNumber: 16,
+    );
+
+    // We need to return MediaItem for the series so the repository can inspect it
+    final detailsItem = MediaItem(
+      id: tmdbId,
+      title: 'T',
+      overview: '',
+      releaseDate: '2020-01-01',
+      mediaType: MediaType.tv,
+      seasons: [
+        TVSeason(id: 1, seasonNumber: 1, episodeCount: 18),
+      ],
+    );
+    when(() => remote.getMediaItem(tmdbId, type: MediaType.tv)).thenAnswer((_) async => detailsItem);
+
+    when(() => local.getAllSeenItems()).thenAnswer((_) async => [
+      SeenItemModel(
+        tmdbId: tmdbId,
+        type: 'tv',
+        title: 'T',
+        seenDate: now,
+        seasonNumber: 1,
+        episodeNumber: 16,
+      )
+    ]);
+    when(() => local.markAsSeen(any())).thenAnswer((_) async {});
+    when(() => local.removeQuickAddItemByTmdbSeasonEpisode(any(), seasonNumber: any(named: 'seasonNumber'), episodeNumber: any(named: 'episodeNumber'))).thenAnswer((_) async {});
+    when(() => local.isOptedOut(any(), seasonNumber: any(named: 'seasonNumber'), episodeNumber: any(named: 'episodeNumber'))).thenAnswer((_) async => false);
+    when(() => local.getQuickAddItems()).thenAnswer((_) async => <QuickAddItemModel>[]);
+    when(() => local.getSeenStatus(tmdbId, 'tv')).thenAnswer((_) async => <SeenItemModel>[
+      SeenItemModel(
+        tmdbId: tmdbId,
+        type: 'tv',
+        title: 'T',
+        seenDate: now,
+        seasonNumber: 1,
+        episodeNumber: 16,
+      )
+    ]);
+
+    when(() => cache.cacheItem(any())).thenAnswer((_) async {});
+    when(() => cache.isSeasonCached(any(), any())).thenReturn(false);
+    when(() => cache.cacheSeason(any(), any(), any())).thenAnswer((_) async {});
+    when(() => cache.getSeason(any(), any())).thenReturn(null);
+
+    when(() => remote.getSeasonDetails(tmdbId, 1)).thenAnswer((_) async => {
+          'episodes': List.generate(18, (i) {
+            final epNum = i + 1;
+            String? airDate;
+            if (epNum <= 16) {
+              airDate = now.subtract(Duration(days: 30 - i)).toIso8601String().substring(0, 10);
+            } else if (epNum == 17) {
+              airDate = now.add(Duration(days: 7)).toIso8601String().substring(0, 10); // future
+            } else {
+              airDate = null; // unaired
+            }
+            return {
+              'episode_number': epNum,
+              'air_date': airDate,
+            };
+          }),
+        });
+
+    final addedQuickAdds = <QuickAddItemModel>[];
+    when(() => local.addQuickAddItem(any())).thenAnswer((inv) async {
+      addedQuickAdds.add(inv.positionalArguments[0] as QuickAddItemModel);
+    });
+
+    await repository.markAsSeen(item);
+
+    // Assuming we remove it from watchlist since markAsSeen tries to do that
+    verifyNever(() => local.addQuickAddItem(any()));
+    expect(addedQuickAdds.isEmpty, isTrue, reason: "When marking episode 16 as seen, we shouldn't get 17 or 18 as quick add because they are unaired/future");
+  });
+}


### PR DESCRIPTION
Closes #81 

- Integrated `workmanager` to handle periodic and one-off background tasks on Android and iOS.
- Introduced `BackgroundTaskService` to manage daily synchronization and manual refresh triggers for "returning series" TV shows.
- Added `refreshReturningSeries` to `MediaRepository` to update metadata and seasons for ongoing shows in the background.
- Updated `SearchProvider` to trigger a one-off background refresh when a user watches the latest available episode of a returning series.
- Enhanced `MediaRepositoryImpl` and quick-add logic to strictly skip episodes with future air dates or missing air dates.
- Refactored `main.dart` with a `BootstrapperApp` to ensure safe dependency initialization and display a loading state during startup.
- Added `getCacheUpdateDate` to `MediaCache` and `MediaRepository` to track when media items were last updated.
- Registered background tasks in `AppDelegate.swift` for iOS and updated `AndroidManifest.xml` for Android compatibility.
- Added unit tests to verify that future or unaired episodes are excluded from quick-add population and "mark as seen" workflows.