### PR TITLE
feat(discovery): enhance display options with toggle buttons for list/grid view and adjustable grid size

### DIFF
--- a/lib/features/discovery/presentation/pages/discovery_page.dart
+++ b/lib/features/discovery/presentation/pages/discovery_page.dart
@@ -9,6 +9,7 @@ import 'package:mediavore/features/media_details/presentation/pages/media_detail
 import 'package:mediavore/features/settings/presentation/providers/settings_provider.dart';
 import 'package:mediavore/core/theme/app_palette.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:mediavore/features/media_details/presentation/widgets/watchlist_icon_button.dart';
 
 class DiscoveryPage extends StatefulWidget {
   final ValueListenable<int>? searchTrigger;
@@ -268,7 +269,7 @@ class _DiscoveryPageState extends State<DiscoveryPage> {
     );
   }
 
-  void _showGridSizeSlider() {
+  void _showDisplayModePicker() {
     final settings = context.read<SettingsProvider>();
     showModalBottomSheet(
       context: context,
@@ -280,32 +281,60 @@ class _DiscoveryPageState extends State<DiscoveryPage> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 const Text(
-                  'Adjust Grid Size',
+                  'Display Options',
                   style: TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                 ),
                 const SizedBox(height: 16),
-                Row(
-                  children: [
-                    const Icon(Icons.grid_view, size: 20),
-                    Expanded(
-                      child: Slider(
-                        value: settings.gridSize,
-                        min: 2,
-                        max: 5,
-                        divisions: 3,
-                        label: settings.gridSize.round().toString(),
-                        onChanged: (v) {
-                          settings.setGridSize(v);
-                          setSheetState(() {});
-                        },
-                      ),
+                ToggleButtons(
+                  isSelected: [
+                    settings.displayMode == DisplayMode.list,
+                    settings.displayMode == DisplayMode.grid,
+                  ],
+                  onPressed: (index) {
+                    settings.setDisplayMode(DisplayMode.values[index]);
+                    setSheetState(() {});
+                  },
+                  borderRadius: BorderRadius.circular(8),
+                  children: const [
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: Icon(Icons.list),
                     ),
-                    Text(
-                      settings.gridSize.round().toString(),
-                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: Icon(Icons.grid_view),
                     ),
                   ],
                 ),
+                if (settings.displayMode == DisplayMode.grid) ...[
+                  const SizedBox(height: 24),
+                  const Text(
+                    'Grid Size',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  Row(
+                    children: [
+                      const Icon(Icons.grid_view, size: 20),
+                      Expanded(
+                        child: Slider(
+                          value: settings.gridSize,
+                          min: 2,
+                          max: 5,
+                          divisions: 3,
+                          label: settings.gridSize.round().toString(),
+                          onChanged: (v) {
+                            settings.setGridSize(v);
+                            setSheetState(() {});
+                          },
+                        ),
+                      ),
+                      Text(
+                        settings.gridSize.round().toString(),
+                        style: const TextStyle(fontWeight: FontWeight.bold),
+                      ),
+                    ],
+                  ),
+                ],
                 const SizedBox(height: 8),
               ],
             ),
@@ -348,9 +377,13 @@ class _DiscoveryPageState extends State<DiscoveryPage> {
             },
           ),
           IconButton(
-            icon: const Icon(Icons.grid_on),
-            onPressed: _showGridSizeSlider,
-            tooltip: 'Grid Size',
+            icon: Icon(
+              settings.displayMode == DisplayMode.grid
+                  ? Icons.grid_on
+                  : Icons.list,
+            ),
+            onPressed: _showDisplayModePicker,
+            tooltip: 'Display Mode',
           ),
           IconButton(
             icon: const Icon(Icons.filter_list),
@@ -388,168 +421,387 @@ class _DiscoveryPageState extends State<DiscoveryPage> {
 
           return RefreshIndicator(
             onRefresh: () async => _refreshDiscovery(),
-            child: GridView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.all(8),
-              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: settings.gridSize.round(),
-                childAspectRatio: 0.65,
-                crossAxisSpacing: 8,
-                mainAxisSpacing: 8,
-              ),
-              itemCount: items.length + (provider.isLoading ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (index == items.length) {
-                  return const Center(child: CircularProgressIndicator());
-                }
+            child: settings.displayMode == DisplayMode.list
+                ? ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.all(8),
+                    itemCount: items.length + (provider.isLoading ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == items.length) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
 
-                final item = items[index];
-                final seenCount = provider.getSeenCount(item);
-                final isSeen = seenCount > 0;
-                final isFinished =
-                    item.mediaType == MediaType.tv &&
-                        item.numberOfEpisodes != null
-                    ? seenCount >= item.numberOfEpisodes!
-                    : isSeen;
+                      final item = items[index];
+                      final seenCount = provider.getSeenCount(item);
+                      final isSeen = seenCount > 0;
+                      final isFinished =
+                          item.mediaType == MediaType.tv &&
+                              item.numberOfEpisodes != null
+                          ? seenCount >= item.numberOfEpisodes!
+                          : isSeen;
 
-                return GestureDetector(
-                  onTap: () => MediaDetailPage.show(context, item),
-                  child: Stack(
-                    clipBehavior: Clip.none,
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: Stack(
-                          fit: StackFit.expand,
-                          children: [
-                            if (item.posterPath != null)
-                              CachedNetworkImage(
-                                imageUrl:
-                                    'https://image.tmdb.org/t/p/w342${item.posterPath}',
-                                fit: BoxFit.cover,
-                                placeholder: (context, url) =>
-                                    Container(color: Colors.grey[800]),
-                                errorWidget: (context, url, error) =>
-                                    const Icon(Icons.error),
-                              )
-                            else
-                              Container(
-                                color: Colors.grey[800],
-                                child: const Icon(
-                                  Icons.movie,
-                                  color: Colors.white54,
-                                ),
-                              ),
-                            Positioned(
-                              bottom: 0,
-                              left: 0,
-                              right: 0,
-                              child: Container(
-                                decoration: const BoxDecoration(
-                                  gradient: LinearGradient(
-                                    begin: Alignment.bottomCenter,
-                                    end: Alignment.topCenter,
-                                    colors: [
-                                      Colors.black87,
-                                      Colors.transparent,
-                                    ],
-                                  ),
-                                ),
-                                padding: const EdgeInsets.all(4),
-                                child: Text(
-                                  item.title,
-                                  maxLines: 2,
-                                  overflow: TextOverflow.ellipsis,
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 10,
-                                    fontWeight: FontWeight.bold,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      // Overlay elements that don't need clipping or need different positioning
-                      if (item.voteAverage != null && item.voteAverage! > 0)
-                        Positioned(
-                          top: 4,
-                          right: 4,
-                          child: Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 4,
-                              vertical: 2,
-                            ),
-                            decoration: BoxDecoration(
-                              color: Colors.black54,
-                              borderRadius: BorderRadius.circular(4),
-                            ),
-                            child: Row(
+                      String lengthText = '';
+                      if (item.mediaType == MediaType.tv) {
+                        lengthText = '${item.numberOfSeasons ?? "?"} seasons';
+                      } else if (item.runtime != null) {
+                        lengthText = '${item.runtime} min';
+                      }
+
+                      return InkWell(
+                        onTap: () => MediaDetailPage.show(context, item),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 4,
+                          ),
+                          leading: SizedBox(
+                            width: 50,
+                            height: 75,
+                            child: Stack(
+                              clipBehavior: Clip.none,
                               children: [
-                                const Icon(
-                                  Icons.star,
-                                  color: Colors.amber,
-                                  size: 10,
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(8),
+                                  child: item.posterPath != null
+                                      ? CachedNetworkImage(
+                                          imageUrl:
+                                              'https://image.tmdb.org/t/p/w92${item.posterPath}',
+                                          fit: BoxFit.cover,
+                                          height: double.infinity,
+                                          width: double.infinity,
+                                          placeholder: (context, url) =>
+                                              Container(
+                                                color: Colors.grey[800],
+                                              ),
+                                          errorWidget: (context, url, error) =>
+                                              const Icon(Icons.error),
+                                        )
+                                      : Container(
+                                          color: Colors.grey[800],
+                                          height: double.infinity,
+                                          width: double.infinity,
+                                          child: const Icon(
+                                            Icons.movie,
+                                            color: Colors.white54,
+                                          ),
+                                        ),
                                 ),
-                                const SizedBox(width: 2),
-                                Text(
-                                  item.voteAverage!.toStringAsFixed(1),
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontSize: 10,
+                                if (isSeen)
+                                  Positioned(
+                                    bottom: -4,
+                                    right: -4,
+                                    child: Container(
+                                      decoration: BoxDecoration(
+                                        color: isFinished
+                                            ? colors.badgeBgSeen
+                                            : colors.badgeBg,
+                                        shape: BoxShape.circle,
+                                        border: Border.all(
+                                          color: Colors.white,
+                                          width: 1.5,
+                                        ),
+                                      ),
+                                      padding: const EdgeInsets.all(2),
+                                      child: Icon(
+                                        isFinished
+                                            ? Icons.done_all
+                                            : Icons.check,
+                                        size: 10,
+                                        color: colors.badgeText,
+                                      ),
+                                    ),
                                   ),
-                                ),
                               ],
                             ),
                           ),
-                        ),
-                      Positioned(
-                        top: 4,
-                        left: 4,
-                        child: Container(
-                          padding: const EdgeInsets.all(2),
-                          decoration: BoxDecoration(
-                            color: Colors.black54,
-                            borderRadius: BorderRadius.circular(4),
+                          title: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  item.title,
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              if (provider.isLiked(item))
+                                Padding(
+                                  padding: const EdgeInsets.only(left: 4.0),
+                                  child: Icon(
+                                    Icons.favorite,
+                                    size: 16,
+                                    color: colors.likeHeart,
+                                  ),
+                                ),
+                            ],
                           ),
-                          child: Icon(
-                            item.mediaType == MediaType.tv
-                                ? Icons.tv
-                                : Icons.movie,
-                            color: Colors.white,
-                            size: 10,
+                          subtitle: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                item.mediaType == MediaType.tv
+                                    ? Icons.tv
+                                    : Icons.movie,
+                                size: 12,
+                                color: Colors.grey,
+                              ),
+                              const SizedBox(width: 4),
+                              Flexible(
+                                child: Text(
+                                  '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : "?"} • $lengthText',
+                                  overflow: TextOverflow.ellipsis,
+                                  maxLines: 1,
+                                ),
+                              ),
+                              if (item.voteAverage != null &&
+                                  item.voteAverage! > 0) ...[
+                                const Text(' • '),
+                                const Icon(
+                                  Icons.star,
+                                  color: Colors.amber,
+                                  size: 12,
+                                ),
+                                const SizedBox(width: 2),
+                                Text(item.voteAverage!.toStringAsFixed(1)),
+                              ],
+                            ],
                           ),
+                          trailing: WatchlistIconButton(item: item),
                         ),
-                      ),
-                      if (isSeen)
-                        Positioned(
-                          right: -4,
-                          bottom: -4,
-                          child: Container(
-                            decoration: BoxDecoration(
-                              color: isFinished
-                                  ? colors.badgeBgSeen
-                                  : colors.badgeBg,
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: Colors.white,
-                                width: 1.5,
+                      );
+                    },
+                  )
+                : GridView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.all(8),
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: settings.gridSize.round(),
+                      childAspectRatio: 0.65,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 8,
+                    ),
+                    itemCount: items.length + (provider.isLoading ? 1 : 0),
+                    itemBuilder: (context, index) {
+                      if (index == items.length) {
+                        return const Center(child: CircularProgressIndicator());
+                      }
+
+                      final item = items[index];
+                      final seenCount = provider.getSeenCount(item);
+                      final isSeen = seenCount > 0;
+                      final isFinished =
+                          item.mediaType == MediaType.tv &&
+                              item.numberOfEpisodes != null
+                          ? seenCount >= item.numberOfEpisodes!
+                          : isSeen;
+
+                      String lengthText = '';
+                      if (item.mediaType == MediaType.tv) {
+                        lengthText = '${item.numberOfSeasons ?? "?"} S';
+                      } else if (item.runtime != null) {
+                        lengthText = '${item.runtime}m';
+                      }
+
+                      return GestureDetector(
+                        onTap: () => MediaDetailPage.show(context, item),
+                        child: Stack(
+                          clipBehavior: Clip.none,
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: Stack(
+                                fit: StackFit.expand,
+                                children: [
+                                  if (item.posterPath != null)
+                                    CachedNetworkImage(
+                                      imageUrl:
+                                          'https://image.tmdb.org/t/p/w342${item.posterPath}',
+                                      fit: BoxFit.cover,
+                                      placeholder: (context, url) =>
+                                          Container(color: Colors.grey[800]),
+                                      errorWidget: (context, url, error) =>
+                                          const Icon(Icons.error),
+                                    )
+                                  else
+                                    Container(
+                                      color: Colors.grey[800],
+                                      child: const Icon(
+                                        Icons.movie,
+                                        color: Colors.white54,
+                                      ),
+                                    ),
+                                  Positioned(
+                                    bottom: 0,
+                                    left: 0,
+                                    right: 0,
+                                    child: Container(
+                                      decoration: const BoxDecoration(
+                                        gradient: LinearGradient(
+                                          begin: Alignment.bottomCenter,
+                                          end: Alignment.topCenter,
+                                          colors: [
+                                            Colors.black87,
+                                            Colors.transparent,
+                                          ],
+                                        ),
+                                      ),
+                                      padding: const EdgeInsets.only(
+                                        left: 6,
+                                        top: 24,
+                                        bottom: 6,
+                                        right: 18,
+                                      ),
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          Row(
+                                            mainAxisSize: MainAxisSize.min,
+                                            children: [
+                                              Flexible(
+                                                child: Text(
+                                                  item.title,
+                                                  maxLines: 1,
+                                                  overflow:
+                                                      TextOverflow.ellipsis,
+                                                  style: const TextStyle(
+                                                    color: Colors.white,
+                                                    fontSize: 11,
+                                                    fontWeight: FontWeight.bold,
+                                                  ),
+                                                ),
+                                              ),
+                                              if (provider.isLiked(item))
+                                                Padding(
+                                                  padding:
+                                                      const EdgeInsets.only(
+                                                        left: 4.0,
+                                                      ),
+                                                  child: Icon(
+                                                    Icons.favorite,
+                                                    size: 10,
+                                                    color: colors.likeHeart,
+                                                  ),
+                                                ),
+                                            ],
+                                          ),
+                                          const SizedBox(height: 2),
+                                          Text(
+                                            '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : ""} • $lengthText',
+                                            style: const TextStyle(
+                                              color: Colors.white70,
+                                              fontSize: 9,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
-                            padding: const EdgeInsets.all(2),
-                            child: Icon(
-                              isFinished ? Icons.done_all : Icons.check,
-                              size: 10,
-                              color: colors.badgeText,
+                            // Overlay elements that don't need clipping or need different positioning
+                            Positioned(
+                              top: 4,
+                              right: 4,
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: [
+                                  if (item.voteAverage != null &&
+                                      item.voteAverage! > 0)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 4,
+                                        vertical: 2,
+                                      ),
+                                      margin: const EdgeInsets.only(right: 4),
+                                      decoration: BoxDecoration(
+                                        color: Colors.black87,
+                                        borderRadius: BorderRadius.circular(4),
+                                      ),
+                                      child: Row(
+                                        children: [
+                                          const Icon(
+                                            Icons.star,
+                                            color: Colors.amber,
+                                            size: 10,
+                                          ),
+                                          const SizedBox(width: 2),
+                                          Text(
+                                            item.voteAverage!.toStringAsFixed(
+                                              1,
+                                            ),
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 10,
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                  Container(
+                                    height: 22,
+                                    width: 22,
+                                    decoration: BoxDecoration(
+                                      color: Colors.black87,
+                                      borderRadius: BorderRadius.circular(4),
+                                    ),
+                                    child: WatchlistIconButton(
+                                      item: item,
+                                      iconSize: 14,
+                                      padding: EdgeInsets.zero,
+                                    ),
+                                  ),
+                                ],
+                              ),
                             ),
-                          ),
+                            Positioned(
+                              top: 4,
+                              left: 4,
+                              child: Container(
+                                padding: const EdgeInsets.all(2),
+                                decoration: BoxDecoration(
+                                  color: Colors.black54,
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Icon(
+                                  item.mediaType == MediaType.tv
+                                      ? Icons.tv
+                                      : Icons.movie,
+                                  color: Colors.white,
+                                  size: 10,
+                                ),
+                              ),
+                            ),
+                            if (isSeen)
+                              Positioned(
+                                right: -4,
+                                bottom: -4,
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: isFinished
+                                        ? colors.badgeBgSeen
+                                        : colors.badgeBg,
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                      color: Colors.white,
+                                      width: 1.5,
+                                    ),
+                                  ),
+                                  padding: const EdgeInsets.all(2),
+                                  child: Icon(
+                                    isFinished ? Icons.done_all : Icons.check,
+                                    size: 10,
+                                    color: colors.badgeText,
+                                  ),
+                                ),
+                              ),
+                          ],
                         ),
-                    ],
+                      );
+                    },
                   ),
-                );
-              },
-            ),
           );
         },
       ),

--- a/lib/features/media_details/presentation/widgets/watchlist_icon_button.dart
+++ b/lib/features/media_details/presentation/widgets/watchlist_icon_button.dart
@@ -7,8 +7,16 @@ import 'package:mediavore/core/theme/app_palette.dart';
 class WatchlistIconButton extends StatelessWidget {
   final MediaItem item;
   final double? iconSize;
+  final EdgeInsetsGeometry? padding;
+  final BoxConstraints? constraints;
 
-  const WatchlistIconButton({super.key, required this.item, this.iconSize});
+  const WatchlistIconButton({
+    super.key,
+    required this.item,
+    this.iconSize,
+    this.padding,
+    this.constraints,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -18,6 +26,8 @@ class WatchlistIconButton extends StatelessWidget {
 
     return IconButton(
       iconSize: iconSize,
+      padding: padding ?? const EdgeInsets.all(8.0),
+      constraints: constraints,
       icon: Icon(
         isInWatchlist ? Icons.bookmark : Icons.bookmark_border,
         color: isInWatchlist ? colors.onWatchlist : null,

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -1576,8 +1576,9 @@ class _MediaListTile extends StatelessWidget {
         child: ListTile(
           leading: _PosterWithBadge(item: item, provider: provider),
           title: Row(
+            mainAxisSize: MainAxisSize.min,
             children: [
-              Expanded(
+              Flexible(
                 child: Text(
                   item.title,
                   maxLines: 1,
@@ -1585,10 +1586,36 @@ class _MediaListTile extends StatelessWidget {
                 ),
               ),
               if (isLiked)
-                Icon(Icons.favorite, size: 16, color: colors.likeHeart),
+                Padding(
+                  padding: const EdgeInsets.only(left: 4.0),
+                  child: Icon(
+                    Icons.favorite,
+                    size: 16,
+                    color: colors.likeHeart,
+                  ),
+                ),
             ],
           ),
-          subtitle: Text('${item.releaseDate} • $lengthText'),
+          subtitle: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(isTv ? Icons.tv : Icons.movie, size: 12, color: Colors.grey),
+              const SizedBox(width: 4),
+              Flexible(
+                child: Text(
+                  '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : "?"} • $lengthText',
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              if (item.voteAverage != null && item.voteAverage! > 0) ...[
+                const Text(' • '),
+                const Icon(Icons.star, color: Colors.amber, size: 12),
+                const SizedBox(width: 2),
+                Text(item.voteAverage!.toStringAsFixed(1)),
+              ],
+            ],
+          ),
           trailing: isEditMode
               ? Checkbox(value: isSelected, onChanged: (_) => onTap())
               : isManualSort
@@ -1624,18 +1651,145 @@ class _MediaGridItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colors = context.appColors;
+    final isTv = item.mediaType == MediaType.tv;
+
+    String lengthText = '';
+    if (isTv) {
+      lengthText = '${item.numberOfSeasons ?? "?"} S';
+    } else if (item.runtime != null) {
+      lengthText = '${item.runtime}m';
+    }
+
     return InkWell(
       onTap: onTap,
       onLongPress: onLongPress,
       child: Stack(
         clipBehavior: Clip.none,
         children: [
-          _PosterWithBadge(
-            item: item,
-            provider: provider,
-            width: double.infinity,
-            height: double.infinity,
-            showBadge: false,
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                _PosterWithBadge(
+                  item: item,
+                  provider: provider,
+                  width: double.infinity,
+                  height: double.infinity,
+                  showBadge: false,
+                ),
+                Positioned(
+                  bottom: 0,
+                  left: 0,
+                  right: 0,
+                  child: Container(
+                    decoration: const BoxDecoration(
+                      gradient: LinearGradient(
+                        begin: Alignment.bottomCenter,
+                        end: Alignment.topCenter,
+                        colors: [Colors.black87, Colors.transparent],
+                      ),
+                    ),
+                    padding: const EdgeInsets.only(
+                      left: 6,
+                      top: 24,
+                      bottom: 6,
+                      right: 18,
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Flexible(
+                              child: Text(
+                                item.title,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 11,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ),
+                            if (provider.isLiked(item))
+                              Padding(
+                                padding: const EdgeInsets.only(left: 4.0),
+                                child: Icon(
+                                  Icons.favorite,
+                                  size: 10,
+                                  color: colors.likeHeart,
+                                ),
+                              ),
+                          ],
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : ""} • $lengthText',
+                          style: const TextStyle(
+                            color: Colors.white70,
+                            fontSize: 9,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 4,
+            right: 4,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (item.voteAverage != null && item.voteAverage! > 0)
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 4,
+                      vertical: 2,
+                    ),
+                    margin: const EdgeInsets.only(right: 4),
+                    decoration: BoxDecoration(
+                      color: Colors.black87,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.star, color: Colors.amber, size: 10),
+                        const SizedBox(width: 2),
+                        Text(
+                          item.voteAverage!.toStringAsFixed(1),
+                          style: const TextStyle(
+                            color: Colors.white,
+                            fontSize: 10,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 4,
+            left: 4,
+            child: Container(
+              padding: const EdgeInsets.all(2),
+              decoration: BoxDecoration(
+                color: Colors.black54,
+                borderRadius: BorderRadius.circular(4),
+              ),
+              child: Icon(
+                item.mediaType == MediaType.tv ? Icons.tv : Icons.movie,
+                color: Colors.white,
+                size: 10,
+              ),
+            ),
           ),
           if (isSelected)
             Positioned.fill(


### PR DESCRIPTION
Closes #87 
Closes #74 

- Added a unified display options control in the discovery page so users can switch between list and grid layouts from one place.
- Replaced the old grid-size-only action with a display mode picker that clearly shows the current view.
- Kept the grid-size slider, but only show it when grid mode is active so the UI stays cleaner.
- Updated the discovery results rendering to support both layouts properly.
- Added a compact list view with poster thumbnails, metadata, and seen/finished indicators.
- Preserved the poster-card grid view for users who prefer the denser browse layout.
- Updated the related saved media and watchlist UI so the new display controls and item presentation stay consistent across discovery surfaces.