### PR TITLE
feat(data_management): implement Quick Add data persistence and UI improvements

### DIFF
--- a/DOCS/export-format.md
+++ b/DOCS/export-format.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-MediaVore uses a single ZIP archive to export/import user data. The archive contains multiple `.csv` files: `seen.csv`, `likes.csv`, `notifications.csv`, `lists.csv`, and a `meta.csv` header with a `version`, `exportedAt` timestamp and `source`.
+MediaVore uses a single ZIP archive to export/import user data. The archive contains multiple `.csv` files: `seen.csv`, `likes.csv`, `notifications.csv`, `quickadd.csv`, `lists.csv`, and a `meta.csv` header with a `version`, `exportedAt` timestamp and `source`.
 
 ## Archive structure
 
@@ -12,6 +12,7 @@ export.zip
 ├── seen.csv
 ├── likes.csv
 ├── notifications.csv
+├── quickadd.csv
 └── lists.csv
 ```
 
@@ -50,6 +51,16 @@ Columns: `tmdbId`, `type`, `title`
 Columns: `tmdbId`, `type`, `title`, `posterPath`, `releaseDate`, `seasonNumber`, `episodeNumber`, `autoNotify`
 
 - `autoNotify` is represented as `true` or `false` string.
+
+### `quickadd.csv`
+
+Columns: `tmdbId`, `type`, `seasonNumber`, `episodeNumber`, `insertedAt`, `airDate`, `title`, `posterPath`
+
+- `tmdbId` (int), `type` ("movie"|"tv")
+- `seasonNumber`, `episodeNumber` (nullable int) -- the next unseen episode for TV series.
+- `insertedAt` (ISO8601 string) -- when this quick add entry was created.
+- `airDate` (nullable ISO8601 string) -- the air date of the episode or movie.
+- `title`, `posterPath` (nullable strings) -- metadata snapshot at insertion time.
 
 ### `lists.csv`
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ Additional features:
 
 MediaVore includes a gamified achievement system to track your viewing habits and milestones. Check out the [Achievements documentation](ACHIEVEMENTS.md) for a full list of available badges.
 
+## Key Features
+
+### Notification Center
+- **Releases Tab**: Track upcoming movie releases and TV episode air dates. Releases are sorted by air date, with unplanned/future releases grouped at the bottom. TV episodes older than 30 days are hidden from view to reduce clutter while remaining tracked for notifications.
+- **Quick Add Tab**: Get AI-suggested next episodes for your favorite TV series based on your watch history. Easily add new series to track with a single tap.
+
+### Data Management
+- **Export/Import**: Full backup and restore of your media library including seen history, likes, notifications, quick add items, and custom lists. Supports three import modes: append, replace, and merge.
+- **Auto-population**: Quick Add is automatically populated from your seen history after importing data, ensuring you don't lose tracking of your viewing streaks.
+
+### Gamification
+- **Achievements**: Unlock badges as you progress through your media journey. Track genre milestones, viewing streaks, runtime records, and more.
+
 ## Project Setup on a New Machine
 
 If you have cloned this project on a new machine, you may encounter errors when trying to run it for the first time. This is often due to missing dependencies or stale auto-generated files that are specific to the previous development environment (like Windows).

--- a/lib/core/utils/export_import_serializer.dart
+++ b/lib/core/utils/export_import_serializer.dart
@@ -6,6 +6,7 @@ import '../../features/media_details/data/models/liked_item.dart';
 import '../../features/media_details/data/models/media_list_item.dart';
 import '../../features/media_details/data/models/notified_item_model.dart';
 import '../../features/media_details/data/models/seen_item_model.dart';
+import '../../features/media_details/data/models/quick_add_item_model.dart';
 
 class ExportEnvelope {
   final int version;
@@ -15,19 +16,22 @@ class ExportEnvelope {
   final List<SeenItemModel> seen;
   final List<LikedItem> likes;
   final List<NotifiedItemModel> notifications;
+  final List<QuickAddItemModel> quickAdd;
   final Map<String, List<MediaListItem>> lists;
 
   ExportEnvelope({
     required this.version,
     required this.exportedAt,
     this.source,
-    List<SeenItemModel>? seen,
-    List<LikedItem>? likes,
-    List<NotifiedItemModel>? notifications,
-    Map<String, List<MediaListItem>>? lists,
+     List<SeenItemModel>? seen,
+     List<LikedItem>? likes,
+     List<NotifiedItemModel>? notifications,
+     List<QuickAddItemModel>? quickAdd,
+     Map<String, List<MediaListItem>>? lists,
   }) : seen = seen ?? [],
        likes = likes ?? [],
        notifications = notifications ?? [],
+       quickAdd = quickAdd ?? [],
        lists = lists ?? {};
 
   List<int> toZipBytes() {
@@ -148,6 +152,38 @@ class ExportEnvelope {
       );
     }
 
+    // quickadd.csv
+    if (quickAdd.isNotEmpty) {
+      final qaRows = <List<dynamic>>[
+        [
+          'tmdbId',
+          'type',
+          'seasonNumber',
+          'episodeNumber',
+          'insertedAt',
+          'airDate',
+          'title',
+          'posterPath',
+        ],
+      ];
+      for (final q in quickAdd) {
+        qaRows.add([
+          q.tmdbId,
+          q.type,
+          q.seasonNumber?.toString() ?? '',
+          q.episodeNumber?.toString() ?? '',
+          q.insertedAt.toIso8601String(),
+          q.airDate?.toIso8601String() ?? '',
+          q.title ?? '',
+          q.posterPath ?? '',
+        ]);
+      }
+      final qaCsv = csv.encode(qaRows);
+      archive.addFile(
+        ArchiveFile('quickadd.csv', qaCsv.length, utf8.encode(qaCsv)),
+      );
+    }
+
     return ZipEncoder().encode(archive);
   }
 
@@ -160,6 +196,7 @@ class ExportEnvelope {
     final List<SeenItemModel> seen = [];
     final List<LikedItem> likes = [];
     final List<NotifiedItemModel> notifications = [];
+    final List<QuickAddItemModel> quickAdd = [];
     final Map<String, List<MediaListItem>> lists = {};
 
     for (final file in archive) {
@@ -340,6 +377,66 @@ class ExportEnvelope {
             ),
           );
         }
+      } else if (filename == 'quickadd.csv') {
+        for (int i = 1; i < rows.length; i++) {
+          final row = rows[i];
+          int tmdbId = 0;
+          String type = 'tv';
+          int? seasonNumber;
+          int? episodeNumber;
+          DateTime insertedAt = DateTime.now();
+          DateTime? airDate;
+          String? title;
+          String? posterPath;
+
+          for (int j = 0; j < headers.length && j < row.length; j++) {
+            final val = row[j];
+            final valStr = val.toString().trim();
+            if (valStr.isEmpty && headers[j] != 'type') continue;
+            switch (headers[j]) {
+              case 'tmdbId':
+                if (val is num)
+                  tmdbId = val.toInt();
+                else
+                  tmdbId = int.tryParse(valStr) ?? 0;
+                break;
+              case 'type':
+                type = valStr;
+                break;
+              case 'seasonNumber':
+                seasonNumber = int.tryParse(valStr);
+                break;
+              case 'episodeNumber':
+                episodeNumber = int.tryParse(valStr);
+                break;
+              case 'insertedAt':
+                insertedAt = DateTime.tryParse(valStr) ?? insertedAt;
+                break;
+              case 'airDate':
+                airDate = DateTime.tryParse(valStr);
+                break;
+              case 'title':
+                title = valStr.isNotEmpty ? valStr : null;
+                break;
+              case 'posterPath':
+                posterPath = valStr.isNotEmpty ? valStr : null;
+                break;
+            }
+          }
+
+          quickAdd.add(
+            QuickAddItemModel(
+              tmdbId: tmdbId,
+              type: type,
+              seasonNumber: seasonNumber,
+              episodeNumber: episodeNumber,
+              insertedAt: insertedAt,
+              airDate: airDate,
+              title: title,
+              posterPath: posterPath,
+            ),
+          );
+        }
       } else if (filename == 'lists.csv') {
         for (int i = 1; i < rows.length; i++) {
           final row = rows[i];
@@ -398,6 +495,7 @@ class ExportEnvelope {
       seen: seen,
       likes: likes,
       notifications: notifications,
+      quickAdd: quickAdd,
       lists: lists,
     );
   }

--- a/lib/core/utils/release_sort.dart
+++ b/lib/core/utils/release_sort.dart
@@ -1,0 +1,51 @@
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+int releaseGroupPriority(NotifiedItem item) {
+  if (item.releaseDate != null) return 0;
+  if (item.type == MediaType.tv &&
+      item.seasonNumber != null &&
+      item.episodeNumber != null) {
+    return 1;
+  }
+  if (item.type == MediaType.tv) return 2;
+  return 3;
+}
+
+List<NotifiedItem> sortReleases(List<NotifiedItem> items) {
+  final sorted = [...items];
+  sorted.sort((a, b) {
+    final priorityA = releaseGroupPriority(a);
+    final priorityB = releaseGroupPriority(b);
+
+    if (priorityA != priorityB) {
+      return priorityA.compareTo(priorityB);
+    }
+
+    if (priorityA == 0 && a.releaseDate != null && b.releaseDate != null) {
+      return a.releaseDate!.compareTo(b.releaseDate!);
+    }
+
+    return a.title.compareTo(b.title);
+  });
+
+  return sorted;
+}
+
+String releaseSubtitleForItem(NotifiedItem item) {
+  if (item.releaseDate != null) {
+    return '';
+  }
+
+  if (item.type == MediaType.tv &&
+      item.seasonNumber != null &&
+      item.episodeNumber != null) {
+    return 'Episode — date TBA';
+  }
+
+  if (item.type == MediaType.tv) {
+    return 'Returning — new season planned';
+  }
+
+  return 'Planned — no release date';
+}

--- a/lib/features/media_details/data/datasources/media_list_local_data_source.dart
+++ b/lib/features/media_details/data/datasources/media_list_local_data_source.dart
@@ -653,4 +653,46 @@ class MediaListLocalDataSource {
       i++;
     }
   }
+
+  Future<void> importQuickAddItems(
+    List<QuickAddItemModel> items, {
+    required ImportMode mode,
+    Function(double progress, String status)? onProgress,
+  }) async {
+    final total = items.length;
+
+    if (mode == ImportMode.replace) {
+      await _isar.writeTxn(() async {
+        await _isar.quickAddItemModels.clear();
+      });
+    }
+
+    if (mode == ImportMode.replace || mode == ImportMode.append) {
+      for (int i = 0; i < items.length; i++) {
+        if (onProgress != null) onProgress(i / total, 'Importing quick add...');
+      }
+
+      await _isar.writeTxn(() async {
+        await _isar.quickAddItemModels.putAll(items);
+      });
+    } else if (mode == ImportMode.merge) {
+      for (int i = 0; i < items.length; i++) {
+        final item = items[i];
+        if (onProgress != null) {
+          onProgress(i / total, 'Processing quick add ${i + 1}');
+        }
+        final existing = await _isar.quickAddItemModels
+            .filter()
+            .tmdbIdEqualTo(item.tmdbId)
+            .seasonNumberEqualTo(item.seasonNumber)
+            .episodeNumberEqualTo(item.episodeNumber)
+            .findFirst();
+        if (existing == null) {
+          await _isar.writeTxn(() async {
+            await _isar.quickAddItemModels.put(item);
+          });
+        }
+      }
+    }
+  }
 }

--- a/lib/features/media_details/presentation/pages/media_detail_page.dart
+++ b/lib/features/media_details/presentation/pages/media_detail_page.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'dart:io';
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/media_details.dart';
@@ -12,12 +14,11 @@ import 'package:mediavore/features/media_details/presentation/widgets/seen_manag
 import 'package:mediavore/features/media_details/presentation/widgets/like_button.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/notify_button.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/watch_next_button.dart';
-import 'package:mediavore/features/media_details/presentation/widgets/watchlist_icon_button.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
-import 'package:mediavore/core/utils/saga_sort.dart';
+import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:share_plus/share_plus.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class MediaDetailPage extends StatefulWidget {
   final MediaItem item;
@@ -31,31 +32,58 @@ class MediaDetailPage extends StatefulWidget {
     this.scrollController,
   });
 
-  static Future<void> show(BuildContext context, MediaItem item) {
-    return showModalBottomSheet(
-      context: context,
-      isScrollControlled: true,
-      useRootNavigator: false,
-      backgroundColor: Colors.transparent,
-      builder: (context) => DraggableScrollableSheet(
-        initialChildSize: 0.8,
-        minChildSize: 0.5,
-        maxChildSize: 0.95,
-        expand: false,
-        builder: (context, scrollController) => Container(
-          decoration: BoxDecoration(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+  static Future<void> show(BuildContext context, MediaItem item) async {
+    // Prefer attaching a persistent bottom sheet to the nearest Scaffold so
+    // the app's persistent bottom navigation (home row) remains visible.
+    final scaffoldState = Scaffold.maybeOf(context);
+    if (scaffoldState != null) {
+      scaffoldState.showBottomSheet((ctx) {
+        return DraggableScrollableSheet(
+          initialChildSize: 0.8,
+          minChildSize: 0.5,
+          maxChildSize: 0.95,
+          expand: false,
+          builder: (context, scrollController) => Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+            ),
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            child: MediaDetailPage(
+              item: item,
+              isSheet: true,
+              scrollController: scrollController,
+            ),
           ),
-          clipBehavior: Clip.antiAliasWithSaveLayer,
-          child: MediaDetailPage(
-            item: item,
-            isSheet: true,
-            scrollController: scrollController,
+        );
+      }, backgroundColor: Colors.transparent);
+    } else {
+      // Fallback to modal bottom sheet if there's no Scaffold in the tree.
+      showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        useRootNavigator: false,
+        backgroundColor: Colors.transparent,
+        builder: (context) => DraggableScrollableSheet(
+          initialChildSize: 0.8,
+          minChildSize: 0.5,
+          maxChildSize: 0.95,
+          expand: false,
+          builder: (context, scrollController) => Container(
+            decoration: BoxDecoration(
+              color: Theme.of(context).scaffoldBackgroundColor,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+            ),
+            clipBehavior: Clip.antiAliasWithSaveLayer,
+            child: MediaDetailPage(
+              item: item,
+              isSheet: true,
+              scrollController: scrollController,
+            ),
           ),
         ),
-      ),
-    );
+      );
+    }
   }
 
   @override
@@ -121,10 +149,9 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
       if (mounted) {
         setState(() {
           _isLoading = false;
-          _isOffline =
-              e.toString().contains('SocketException') ||
-              e.toString().contains('Network error') ||
-              e.toString().contains('connectionError');
+          _isOffline = e.toString().contains('SocketException') ||
+                       e.toString().contains('Network error') ||
+                       e.toString().contains('connectionError');
         });
       }
     }
@@ -132,10 +159,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
 
   Future<void> _fetchSeenStatus() async {
     final provider = context.read<SearchProvider>();
-    final status = await provider.loadSeenStatusForItem(
-      widget.item.id,
-      widget.item.mediaType,
-    );
+    final status = await provider.loadSeenStatusForItem(widget.item.id, widget.item.mediaType);
     if (mounted) {
       setState(() {
         _seenStatus = status;
@@ -145,7 +169,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
 
   Future<void> _fetchSeasonDetails(int seasonNumber) async {
     if (_episodesBySeason.containsKey(seasonNumber)) {
-      setState(() {
+       setState(() {
         _expandedSeason = _expandedSeason == seasonNumber ? null : seasonNumber;
       });
       return;
@@ -158,10 +182,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
 
     try {
       final provider = context.read<SearchProvider>();
-      final data = await provider.getSeasonDetails(
-        widget.item.id,
-        seasonNumber,
-      );
+      final data = await provider.getSeasonDetails(widget.item.id, seasonNumber);
       if (mounted) {
         setState(() {
           _episodesBySeason[seasonNumber] = data['episodes'] ?? [];
@@ -175,9 +196,101 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
           _expandedSeason = null;
         });
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Cannot load season details while offline.'),
+          const SnackBar(content: Text('Cannot load season details while offline.')),
+        );
+      }
+    }
+  }
+
+  Future<void> _exportHistory() async {
+    final provider = context.read<SearchProvider>();
+    final data = (await provider.loadSeenStatusForItem(
+      widget.item.id,
+      widget.item.mediaType,
+    ))
+        .map(
+          (entry) => {
+            'id': entry.id,
+            'tmdbId': entry.tmdbId,
+            'type': entry.type.name,
+            'title': entry.title,
+            'posterPath': entry.posterPath,
+            'seenDate': entry.seenDate.toIso8601String(),
+            'seasonNumber': entry.seasonNumber,
+            'episodeNumber': entry.episodeNumber,
+            'runtime': entry.runtime,
+            'genres': entry.genres,
+          },
+        )
+        .toList();
+
+    if (data.isEmpty) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('No history to export for this item.')),
+        );
+      }
+      return;
+    }
+
+    final jsonString = jsonEncode(data);
+    final fileName = 'mediavore_${widget.item.title.replaceAll(' ', '_')}_history.json';
+
+    if (mounted) {
+      showModalBottomSheet(
+        context: context,
+        builder: (context) => SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.save_alt),
+                title: const Text('Save to device'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  await _saveFileToDevice(context, jsonString, fileName);
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.share),
+                title: const Text('Share via System'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  final tempDir = await getTemporaryDirectory();
+                  final tempFile = File('${tempDir.path}/$fileName');
+                  await tempFile.writeAsString(jsonString);
+                  await Share.shareXFiles(
+                    [XFile(tempFile.path, mimeType: 'application/json')],
+                    text: 'Seen history for ${widget.item.title}',
+                  );
+                },
+              ),
+            ],
           ),
+        ),
+      );
+    }
+  }
+
+  Future<void> _saveFileToDevice(BuildContext context, String jsonString, String fileName) async {
+    try {
+      final bytes = utf8.encode(jsonString);
+      final result = await FilePicker.platform.saveFile(
+        dialogTitle: 'Save History',
+        fileName: fileName,
+        initialDirectory: '/storage/emulated/0/Download/MediaVore',
+        bytes: bytes,
+      );
+
+      if (result != null && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('File saved successfully')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Save failed: $e')),
         );
       }
     }
@@ -204,19 +317,8 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
   Widget build(BuildContext context) {
     final itemToDisplay = _mediaDetails?.item ?? widget.item;
     final colors = context.appColors;
-    final brightness = Theme.of(context).brightness;
-    final baseBgColor = brightness == Brightness.dark
-        ? Colors.black
-        : Theme.of(context).scaffoldBackgroundColor;
-    final overlayHeight =
-        MediaQuery.of(context).padding.top + (widget.isSheet ? 96.0 : 120.0);
-    final overlayStartColor = brightness == Brightness.dark
-        ? baseBgColor.withValues(alpha: 0.75)
-        : baseBgColor.withValues(alpha: 0.95);
 
-    final String directorLabel = itemToDisplay.mediaType == MediaType.tv
-        ? 'Creator'
-        : 'Director';
+    final String directorLabel = itemToDisplay.mediaType == MediaType.tv ? 'Creator' : 'Director';
 
     final int uniqueEpisodesSeenTotal = _seenStatus
         .where((s) => s.seasonNumber != null && s.episodeNumber != null)
@@ -232,16 +334,17 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
             expandedHeight: widget.isSheet ? 300 : 400,
             pinned: true,
             leading: widget.isSheet
-                ? IconButton(
-                    icon: const Icon(Icons.keyboard_arrow_down),
-                    onPressed: () => Navigator.pop(context),
-                  )
+                ? IconButton(icon: const Icon(Icons.keyboard_arrow_down), onPressed: () => Navigator.pop(context))
                 : null,
             title: Text(itemToDisplay.title),
             actions: [
               LikeButton(item: itemToDisplay),
               NotifyButton(item: itemToDisplay),
-              WatchlistIconButton(item: itemToDisplay),
+              IconButton(
+                icon: const Icon(Icons.file_upload_outlined),
+                onPressed: _exportHistory,
+                tooltip: 'Export history for this item',
+              ),
               if (itemToDisplay.mediaType == MediaType.movie)
                 SeenManager(
                   key: ValueKey('seen_movie_${itemToDisplay.id}'),
@@ -250,57 +353,22 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                 ),
             ],
             flexibleSpace: FlexibleSpaceBar(
-              background: Stack(
-                fit: StackFit.expand,
-                children: [
-                  itemToDisplay.posterPath != null &&
-                          !Platform.environment.containsKey('FLUTTER_TEST')
-                      ? Image.network(
-                          'https://image.tmdb.org/t/p/w500${itemToDisplay.posterPath}',
-                          width: double.infinity,
-                          fit: BoxFit.cover,
-                          errorBuilder: (context, error, stackTrace) =>
-                              Container(
-                                color: colors.placeholder,
-                                child: Center(
-                                  child: Icon(
-                                    Icons.broken_image,
-                                    size: 64,
-                                    color: colors.comments,
-                                  ),
-                                ),
-                              ),
-                        )
-                      : Container(
-                          color: colors.placeholder,
-                          child: Center(
-                            child: Icon(
-                              Icons.movie,
-                              size: 100,
-                              color: colors.comments,
-                            ),
-                          ),
-                        ),
-
-                  // Top gradient overlay to improve contrast for title/actions
-                  Align(
-                    alignment: Alignment.topCenter,
-                    child: Container(
-                      height: overlayHeight,
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          begin: Alignment.topCenter,
-                          end: Alignment.bottomCenter,
-                          colors: [
-                            overlayStartColor,
-                            overlayStartColor.withValues(alpha: 0.0),
-                          ],
-                        ),
+              background: itemToDisplay.posterPath != null && !Platform.environment.containsKey('FLUTTER_TEST')
+                  ? Image.network(
+                      'https://image.tmdb.org/t/p/w500${itemToDisplay.posterPath}',
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Container(
+                        color: colors.placeholder,
+                        child: Center(child: Icon(Icons.broken_image, size: 64, color: colors.comments)),
+                      ),
+                    )
+                  : Container(
+                      color: colors.placeholder,
+                      child: Center(
+                        child: Icon(Icons.movie, size: 100, color: colors.comments),
                       ),
                     ),
-                  ),
-                ],
-              ),
             ),
           ),
           if (widget.isSheet)
@@ -324,12 +392,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
               sliver: SliverList(
                 delegate: SliverChildListDelegate([
                   if (_isLoading)
-                    const Center(
-                      child: Padding(
-                        padding: EdgeInsets.all(32.0),
-                        child: CircularProgressIndicator(),
-                      ),
-                    )
+                    const Center(child: Padding(padding: EdgeInsets.all(32.0), child: CircularProgressIndicator()))
                   else ...[
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.start,
@@ -341,14 +404,10 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                           ),
                         ),
                         if (itemToDisplay.voteAverage != null && !_isOffline)
-                          Badge(
+                           Badge(
                             label: Row(
                               children: [
-                                Icon(
-                                  Icons.star,
-                                  size: 12,
-                                  color: colors.badgeText,
-                                ),
+                                Icon(Icons.star, size: 12, color: colors.badgeText),
                                 const SizedBox(width: 4),
                                 Text(
                                   itemToDisplay.voteAverage!.toStringAsFixed(1),
@@ -365,12 +424,10 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                     _buildWatchProviders(),
                     const SizedBox(height: 8),
 
-                    if (itemToDisplay.mediaType == MediaType.tv &&
-                        itemToDisplay.numberOfEpisodes != null) ...[
+                    if (itemToDisplay.mediaType == MediaType.tv && itemToDisplay.numberOfEpisodes != null) ...[
                       LinearProgressIndicator(
                         value: itemToDisplay.numberOfEpisodes! > 0
-                            ? uniqueEpisodesSeenTotal /
-                                  itemToDisplay.numberOfEpisodes!
+                            ? uniqueEpisodesSeenTotal / itemToDisplay.numberOfEpisodes!
                             : 0,
                         backgroundColor: colors.placeholder,
                         color: colors.onWatchlist,
@@ -378,16 +435,15 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                       const SizedBox(height: 4),
                       Text(
                         'Progress: $uniqueEpisodesSeenTotal / ${itemToDisplay.numberOfEpisodes} episodes seen',
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colors.onWatchlist,
-                          fontWeight: FontWeight.bold,
-                        ),
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(color: colors.onWatchlist, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
                     ],
 
                     if (itemToDisplay.mediaType == MediaType.tv)
-                      WatchNextButton(item: itemToDisplay),
+                      WatchNextButton(
+                        item: itemToDisplay,
+                      ),
 
                     if (_isOffline)
                       Container(
@@ -395,11 +451,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                         width: double.infinity,
                         child: Column(
                           children: [
-                            Icon(
-                              Icons.cloud_off,
-                              size: 48,
-                              color: colors.warning,
-                            ),
+                            Icon(Icons.cloud_off, size: 48, color: colors.warning),
                             const SizedBox(height: 8),
                             Text(
                               'Offline Mode',
@@ -424,56 +476,27 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                         spacing: 16,
                         runSpacing: 8,
                         children: [
-                          _SearchIconText(
-                            icon: Icons.calendar_today,
-                            text: itemToDisplay.releaseDate,
-                          ),
+                          _SearchIconText(icon: Icons.calendar_today, text: itemToDisplay.releaseDate),
                           if (itemToDisplay.status != null)
-                            _SearchIconText(
-                              icon: Icons.info_outline,
-                              text: itemToDisplay.status!,
-                            ),
-                          if (itemToDisplay.mediaType == MediaType.movie &&
-                              itemToDisplay.runtime != null)
-                            _SearchIconText(
-                              icon: Icons.access_time,
-                              text: Formatters.formatRuntime(
-                                itemToDisplay.runtime,
-                              ),
-                            ),
-                          if (itemToDisplay.mediaType == MediaType.tv &&
-                              itemToDisplay.numberOfSeasons != null)
-                            _SearchIconText(
-                              icon: Icons.tv,
-                              text: '${itemToDisplay.numberOfSeasons} Seasons',
-                            ),
-                          if (itemToDisplay.mediaType == MediaType.tv &&
-                              itemToDisplay.numberOfEpisodes != null)
-                            _SearchIconText(
-                              icon: Icons.subscriptions,
-                              text:
-                                  '${itemToDisplay.numberOfEpisodes} Episodes',
-                            ),
+                            _SearchIconText(icon: Icons.info_outline, text: itemToDisplay.status!),
+                          if (itemToDisplay.mediaType == MediaType.movie && itemToDisplay.runtime != null)
+                            _SearchIconText(icon: Icons.access_time, text: Formatters.formatRuntime(itemToDisplay.runtime)),
+                          if (itemToDisplay.mediaType == MediaType.tv && itemToDisplay.numberOfSeasons != null)
+                            _SearchIconText(icon: Icons.tv, text: '${itemToDisplay.numberOfSeasons} Seasons'),
+                          if (itemToDisplay.mediaType == MediaType.tv && itemToDisplay.numberOfEpisodes != null)
+                            _SearchIconText(icon: Icons.subscriptions, text: '${itemToDisplay.numberOfEpisodes} Episodes'),
                         ],
                       ),
                       const SizedBox(height: 12),
-                      if (itemToDisplay.genres != null &&
-                          itemToDisplay.genres!.isNotEmpty)
+                      if (itemToDisplay.genres != null && itemToDisplay.genres!.isNotEmpty)
                         Wrap(
                           spacing: 8,
-                          children: itemToDisplay.genres!
-                              .map(
-                                (genre) => ActionChip(
-                                  label: Text(
-                                    genre,
-                                    style: const TextStyle(fontSize: 12),
-                                  ),
-                                  padding: EdgeInsets.zero,
-                                  visualDensity: VisualDensity.compact,
-                                  onPressed: () => _onGenreTapped(genre),
-                                ),
-                              )
-                              .toList(),
+                          children: itemToDisplay.genres!.map((genre) => ActionChip(
+                            label: Text(genre, style: const TextStyle(fontSize: 12)),
+                            padding: EdgeInsets.zero,
+                            visualDensity: VisualDensity.compact,
+                            onPressed: () => _onGenreTapped(genre),
+                          )).toList(),
                         ),
                       const SizedBox(height: 8),
 
@@ -487,10 +510,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                       const SizedBox(height: 16),
                       const Text(
                         'Overview',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
+                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
                       Text(
@@ -499,15 +519,11 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                       ),
                     ],
 
-                    if (itemToDisplay.mediaType == MediaType.tv &&
-                        itemToDisplay.seasons != null) ...[
+                    if (itemToDisplay.mediaType == MediaType.tv && itemToDisplay.seasons != null) ...[
                       const SizedBox(height: 24),
                       const Text(
                         'Seasons',
-                        style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
+                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
                       ListView.builder(
@@ -519,93 +535,55 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                           final season = itemToDisplay.seasons![index];
                           final seasonNumber = season.seasonNumber;
                           final isExpanded = _expandedSeason == seasonNumber;
-                          final isLoading =
-                              _loadingSeasons[seasonNumber] ?? false;
+                          final isLoading = _loadingSeasons[seasonNumber] ?? false;
 
                           final episodesSeenInSeason = _seenStatus
-                              .where(
-                                (s) =>
-                                    s.seasonNumber == seasonNumber &&
-                                    s.episodeNumber != null,
-                              )
+                              .where((s) => s.seasonNumber == seasonNumber && s.episodeNumber != null)
                               .map((s) => s.episodeNumber)
                               .toSet()
                               .length;
-                          final isComplete =
-                              episodesSeenInSeason == season.episodeCount &&
-                              season.episodeCount > 0;
+                          final isComplete = episodesSeenInSeason == season.episodeCount && season.episodeCount > 0;
 
                           return Column(
                             children: [
                               ListTile(
                                 contentPadding: EdgeInsets.zero,
-                                title: Text(
-                                  season.name ?? 'Season $seasonNumber',
-                                ),
+                                title: Text(season.name ?? 'Season $seasonNumber'),
                                 subtitle: Text(
                                   '$episodesSeenInSeason / ${season.episodeCount} episodes seen',
                                   style: TextStyle(
-                                    color: isComplete
-                                        ? colors.onWatchlist
-                                        : null,
-                                    fontWeight: isComplete
-                                        ? FontWeight.bold
-                                        : null,
+                                    color: isComplete ? colors.onWatchlist : null,
+                                    fontWeight: isComplete ? FontWeight.bold : null,
                                   ),
                                 ),
                                 trailing: Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
-                                    if (isComplete)
-                                      Icon(
-                                        Icons.check_circle,
-                                        color: colors.onWatchlist,
-                                      ),
+                                    if (isComplete) Icon(Icons.check_circle, color: colors.onWatchlist),
                                     isLoading
-                                        ? const SizedBox(
-                                            width: 20,
-                                            height: 20,
-                                            child: CircularProgressIndicator(
-                                              strokeWidth: 2,
-                                            ),
-                                          )
-                                        : Icon(
-                                            isExpanded
-                                                ? Icons.expand_less
-                                                : Icons.expand_more,
-                                          ),
+                                      ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                                      : Icon(isExpanded ? Icons.expand_less : Icons.expand_more),
                                   ],
                                 ),
                                 onTap: () => _fetchSeasonDetails(seasonNumber),
                               ),
-                              if (isExpanded &&
-                                  _episodesBySeason.containsKey(seasonNumber))
+                              if (isExpanded && _episodesBySeason.containsKey(seasonNumber))
                                 Padding(
                                   padding: const EdgeInsets.only(left: 16.0),
                                   child: Column(
-                                    children: _episodesBySeason[seasonNumber]!
-                                        .map<Widget>((episode) {
-                                          return ListTile(
-                                            contentPadding: EdgeInsets.zero,
-                                            title: Text(
-                                              'E${episode['episode_number']}: ${episode['name']}',
-                                            ),
-                                            subtitle: Text(
-                                              episode['air_date'] ?? '',
-                                            ),
-                                            trailing: SeenManager(
-                                              key: ValueKey(
-                                                'seen_ep_${itemToDisplay.id}_${seasonNumber}_${episode['episode_number']}',
-                                              ),
-                                              item: itemToDisplay,
-                                              seasonNumber: seasonNumber,
-                                              episodeNumber:
-                                                  episode['episode_number']
-                                                      as int,
-                                            ),
-                                          );
-                                        })
-                                        .toList(),
+                                    children: _episodesBySeason[seasonNumber]!.map<Widget>((episode) {
+                                      return ListTile(
+                                        contentPadding: EdgeInsets.zero,
+                                        title: Text('E${episode['episode_number']}: ${episode['name']}'),
+                                        subtitle: Text(episode['air_date'] ?? ''),
+                                        trailing: SeenManager(
+                                          key: ValueKey('seen_ep_${itemToDisplay.id}_${seasonNumber}_${episode['episode_number']}'),
+                                          item: itemToDisplay,
+                                          seasonNumber: seasonNumber,
+                                          episodeNumber: episode['episode_number'] as int,
+                                        ),
+                                      );
+                                    }).toList(),
                                   ),
                                 ),
                             ],
@@ -619,9 +597,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                       const Text(
                         'Cast',
                         style: TextStyle(
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
+                            fontSize: 18, fontWeight: FontWeight.bold),
                       ),
                       const SizedBox(height: 8),
                       SizedBox(
@@ -632,79 +608,64 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                           itemBuilder: (context, index) {
                             final member = _mediaDetails!.cast[index];
                             return GestureDetector(
-                              onTap: () {
-                                ActorDetailPage.show(
-                                  context,
-                                  actorId: member.id,
-                                  actorName: member.name,
-                                );
-                              },
-                              child: Container(
-                                width: 100,
-                                margin: const EdgeInsets.only(right: 12.0),
-                                child: Column(
-                                  children: [
-                                    member.profilePath != null &&
-                                            !Platform.environment.containsKey(
-                                              'FLUTTER_TEST',
-                                            )
-                                        ? CircleAvatar(
-                                            radius: 40,
-                                            backgroundImage: NetworkImage(
-                                              'https://image.tmdb.org/t/p/w185${member.profilePath}',
-                                            ),
-                                          )
-                                        : CircleAvatar(
-                                            radius: 40,
-                                            backgroundColor: colors.placeholder,
-                                            child: Icon(
-                                              Icons.person,
-                                              color: colors.comments,
-                                            ),
-                                          ),
-                                    const SizedBox(height: 4),
-                                    Text(
-                                      member.name,
-                                      textAlign: TextAlign.center,
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: const TextStyle(
-                                        fontWeight: FontWeight.bold,
+                                onTap: () {
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (context) => ActorDetailPage(
+                                        actorId: member.id,
+                                        actorName: member.name,
                                       ),
                                     ),
-                                    Text(
-                                      member.character,
-                                      textAlign: TextAlign.center,
-                                      maxLines: 2,
-                                      overflow: TextOverflow.ellipsis,
-                                      style: Theme.of(
-                                        context,
-                                      ).textTheme.bodySmall,
-                                    ),
-                                  ],
-                                ),
-                              ),
+                                  );
+                                },
+                                child: Container(
+                                  width: 100,
+                                  margin:
+                                      const EdgeInsets.only(right: 12.0),
+                                  child: Column(
+                                    children: [
+                                      member.profilePath != null && !Platform.environment.containsKey('FLUTTER_TEST')
+                                          ? CircleAvatar(
+                                              radius: 40,
+                                              backgroundImage: NetworkImage(
+                                                  'https://image.tmdb.org/t/p/w185${member.profilePath}'),
+                                            )
+                                          : CircleAvatar(
+                                              radius: 40,
+                                              backgroundColor: colors.placeholder,
+                                              child: Icon(Icons.person, color: colors.comments),
+                                            ),
+                                      const SizedBox(height: 4),
+                                      Text(
+                                        member.name,
+                                        textAlign: TextAlign.center,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: const TextStyle(fontWeight: FontWeight.bold),
+                                      ),
+                                      Text(
+                                        member.character,
+                                        textAlign: TextAlign.center,
+                                        maxLines: 2,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: Theme.of(context).textTheme.bodySmall,
+                                      ),
+                                    ],
+                                  ),
+                                )
                             );
                           },
                         ),
                       ),
 
-                      // Saga section goes first if available
-                      if (_mediaDetails!.collection != null &&
-                          _mediaDetails!.collection!.isNotEmpty)
-                        _buildSagaList(
-                          'Saga',
-                          _mediaDetails!.collection!,
-                          itemToDisplay.id,
-                        ),
                       _buildHorizontalList('Similar', _mediaDetails!.similar),
-                      _buildHorizontalList(
-                        'Recommendations',
-                        _mediaDetails!.recommendations,
-                      ),
+                      _buildHorizontalList('Recommendations', _mediaDetails!.recommendations),
                     ],
                     const SizedBox(height: 24),
-                    MediaListManager(item: itemToDisplay),
+                    MediaListManager(
+                      item: itemToDisplay,
+                    ),
                     const SizedBox(height: 40),
                   ],
                 ]),
@@ -741,8 +702,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(8),
                 child: CachedNetworkImage(
-                  imageUrl:
-                      'https://image.tmdb.org/t/p/original${provider['logo_path']}',
+                  imageUrl: 'https://image.tmdb.org/t/p/original${provider['logo_path']}',
                   width: 40,
                   height: 40,
                 ),
@@ -755,13 +715,9 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
   }
 
   Widget _buildTrailers() {
-    if (_mediaDetails?.videos == null || _mediaDetails!.videos!.isEmpty) {
-      return const SizedBox.shrink();
-    }
+    if (_mediaDetails?.videos == null || _mediaDetails!.videos!.isEmpty) return const SizedBox.shrink();
 
-    final trailers = _mediaDetails!.videos!
-        .where((v) => v['type'] == 'Trailer' && v['site'] == 'YouTube')
-        .toList();
+    final trailers = _mediaDetails!.videos!.where((v) => v['type'] == 'Trailer' && v['site'] == 'YouTube').toList();
     if (trailers.isEmpty) return const SizedBox.shrink();
 
     return Padding(
@@ -769,10 +725,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text(
-            'Trailers',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-          ),
+          const Text('Trailers', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
           const SizedBox(height: 8),
           SizedBox(
             height: 100,
@@ -784,10 +737,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                 final key = trailer['key'];
                 return GestureDetector(
                   onTap: () {
-                    Share.share(
-                      'https://www.youtube.com/watch?v=$key',
-                      subject: 'Watch Trailer',
-                    );
+                    Share.share('https://www.youtube.com/watch?v=$key', subject: 'Watch Trailer');
                   },
                   child: Container(
                     width: 160,
@@ -807,11 +757,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                             width: 160,
                           ),
                         ),
-                        const Icon(
-                          Icons.play_circle_fill,
-                          color: Colors.white,
-                          size: 40,
-                        ),
+                        const Icon(Icons.play_circle_fill, color: Colors.white, size: 40),
                       ],
                     ),
                   ),
@@ -831,10 +777,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         const SizedBox(height: 24),
-        Text(
-          title,
-          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
+        Text(title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
         const SizedBox(height: 8),
         SizedBox(
           height: 150,
@@ -856,116 +799,16 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
                         borderRadius: BorderRadius.circular(8),
                         child: item.posterPath != null
                             ? CachedNetworkImage(
-                                imageUrl:
-                                    'https://image.tmdb.org/t/p/w185${item.posterPath}',
+                                imageUrl: 'https://image.tmdb.org/t/p/w185${item.posterPath}',
                                 height: 120,
                                 fit: BoxFit.cover,
-                                placeholder: (context, url) =>
-                                    Container(color: Colors.grey[200]),
-                                errorWidget: (context, url, error) => Icon(
-                                  item.mediaType == MediaType.tv
-                                      ? Icons.tv
-                                      : Icons.movie,
-                                ),
+                                placeholder: (context, url) => Container(color: Colors.grey[200]),
+                                errorWidget: (context, url, error) => Icon(item.mediaType == MediaType.tv ? Icons.tv : Icons.movie),
                               )
-                            : Container(
-                                height: 120,
-                                color: Colors.grey[300],
-                                child: Icon(
-                                  item.mediaType == MediaType.tv
-                                      ? Icons.tv
-                                      : Icons.movie,
-                                ),
-                              ),
+                            : Container(height: 120, color: Colors.grey[300], child: Icon(item.mediaType == MediaType.tv ? Icons.tv : Icons.movie)),
                       ),
                       const SizedBox(height: 4),
-                      Text(
-                        item.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 12),
-                      ),
-                    ],
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// Builds a saga/collection horizontal list.
-  ///
-  /// `items` are first sorted chronologically (movies by `releaseDate`,
-  /// TV by `lastEpisodeAirDate`) and then rotated so elements after
-  /// `currentId` appear first. The current item is omitted.
-  Widget _buildSagaList(String title, List<MediaItem>? items, int currentId) {
-    if (items == null || items.isEmpty) return const SizedBox.shrink();
-
-    final rotated = rotateSagaElements(items, currentId);
-
-    if (rotated.isEmpty) return const SizedBox.shrink();
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const SizedBox(height: 24),
-        Text(
-          title,
-          style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 8),
-        SizedBox(
-          height: 150,
-          child: ListView.builder(
-            scrollDirection: Axis.horizontal,
-            itemCount: rotated.length,
-            itemBuilder: (context, index) {
-              final item = rotated[index];
-              return GestureDetector(
-                onTap: () {
-                  MediaDetailPage.show(context, item);
-                },
-                child: Container(
-                  width: 100,
-                  margin: const EdgeInsets.only(right: 12),
-                  child: Column(
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.circular(8),
-                        child: item.posterPath != null
-                            ? CachedNetworkImage(
-                                imageUrl:
-                                    'https://image.tmdb.org/t/p/w185${item.posterPath}',
-                                height: 120,
-                                fit: BoxFit.cover,
-                                placeholder: (context, url) =>
-                                    Container(color: Colors.grey[200]),
-                                errorWidget: (context, url, error) => Icon(
-                                  item.mediaType == MediaType.tv
-                                      ? Icons.tv
-                                      : Icons.movie,
-                                ),
-                              )
-                            : Container(
-                                height: 120,
-                                color: Colors.grey[300],
-                                child: Icon(
-                                  item.mediaType == MediaType.tv
-                                      ? Icons.tv
-                                      : Icons.movie,
-                                ),
-                              ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        item.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: const TextStyle(fontSize: 12),
-                      ),
+                      Text(item.title, maxLines: 1, overflow: TextOverflow.ellipsis, style: const TextStyle(fontSize: 12)),
                     ],
                   ),
                 ),

--- a/lib/features/media_details/presentation/pages/notification_center_page.dart
+++ b/lib/features/media_details/presentation/pages/notification_center_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:mediavore/core/utils/release_sort.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
 import 'package:mediavore/features/media_details/presentation/pages/media_detail_page.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:mediavore/features/settings/presentation/pages/settings_page.dart';
@@ -122,33 +124,20 @@ class _ReleasesTabState extends State<_ReleasesTab> {
     return Consumer<SearchProvider>(
       builder: (context, provider, child) {
         final now = DateTime.now();
-        final startOfDay = DateTime(now.year, now.month, now.day);
-        final oneMonthAgo = startOfDay.subtract(const Duration(days: 30));
 
-        final releases = provider.notifiedItems.where((item) {
-          if (item.releaseDate == null) {
-            return false;
-          }
-
-          final releaseDate = item.releaseDate!;
-          final releaseDay = DateTime(
-            releaseDate.year,
-            releaseDate.month,
-            releaseDate.day,
-          );
-
+        // Build the releases list: include all notified items but filter out things
+        // the user already marked as seen. We'll then sort by concrete date first
+        // and append unplanned items grouped by type.
+        final filtered = <NotifiedItem>[];
+        for (final item in provider.notifiedItems) {
           // Filtering by "Seen" status
+          bool isSeen = false;
           if (item.type == MediaType.movie) {
             final seenCount = provider.seenItems
                 .where((s) => s.tmdbId == item.tmdbId)
                 .length;
-            if (seenCount > 0) {
-              return false;
-            }
-          }
-
-          if (item.type == MediaType.tv) {
-            // FIX: Use season and episode number for precise filtering
+            if (seenCount > 0) isSeen = true;
+          } else if (item.type == MediaType.tv) {
             if (item.seasonNumber != null && item.episodeNumber != null) {
               final isEpSeen = provider.seenItems.any(
                 (s) =>
@@ -157,11 +146,14 @@ class _ReleasesTabState extends State<_ReleasesTab> {
                     s.seasonNumber == item.seasonNumber &&
                     s.episodeNumber == item.episodeNumber,
               );
-              if (isEpSeen) {
-                return false;
-              }
-            } else {
+              if (isEpSeen) isSeen = true;
+            } else if (item.releaseDate != null) {
               // Fallback to date-based logic ONLY if episode info is missing
+              final releaseDay = DateTime(
+                item.releaseDate!.year,
+                item.releaseDate!.month,
+                item.releaseDate!.day,
+              );
               final alreadySeenRecent = provider.seenItems.any(
                 (s) =>
                     s.tmdbId == item.tmdbId &&
@@ -169,18 +161,23 @@ class _ReleasesTabState extends State<_ReleasesTab> {
                     (s.seenDate.isAfter(releaseDay) ||
                         DateUtils.isSameDay(s.seenDate, releaseDay)),
               );
-              if (alreadySeenRecent) {
-                return false;
-              }
+              if (alreadySeenRecent) isSeen = true;
             }
           }
 
-          // Check if it's within our window
-          return releaseDay.isAfter(oneMonthAgo) ||
-              DateUtils.isSameDay(releaseDay, startOfDay);
-        }).toList();
+          if (!isSeen) {
+            // Skip old TV releases (30+ days) to reduce clutter, but keep them notified
+            if (item.type == MediaType.tv && item.releaseDate != null) {
+              final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+              if (item.releaseDate!.isBefore(thirtyDaysAgo)) {
+                continue; // Hide old episode, user can catch up
+              }
+            }
+            filtered.add(item);
+          }
+        }
 
-        releases.sort((a, b) => a.releaseDate!.compareTo(b.releaseDate!));
+        final releases = sortReleases(filtered);
 
         return RefreshIndicator(
           onRefresh: widget.onRefresh,
@@ -196,14 +193,21 @@ class _ReleasesTabState extends State<_ReleasesTab> {
                   itemCount: releases.length,
                   itemBuilder: (context, index) {
                     final item = releases[index];
-                    final isReleased = !item.releaseDate!.isAfter(now);
+                    final isReleased = item.releaseDate != null
+                        ? !item.releaseDate!.isAfter(now)
+                        : false;
 
                     String title = item.title;
-                    if (item.type == MediaType.tv &&
-                        item.seasonNumber != null) {
-                      title +=
-                          ' (S${item.seasonNumber} E${item.episodeNumber})';
+                    if (item.type == MediaType.tv && item.seasonNumber != null) {
+                      title += ' (S${item.seasonNumber} E${item.episodeNumber})';
                     }
+
+                    final subtitleText = item.releaseDate != null
+                        ? '${isReleased ? "Released" : "Releases"}: ${DateFormat.yMMMd().format(item.releaseDate!)}'
+                        : releaseSubtitleForItem(item);
+                    final subtitleColor = item.releaseDate != null
+                        ? (isReleased ? Colors.green : Colors.orange)
+                        : Colors.grey;
 
                     return ListTile(
                       leading: item.posterPath != null
@@ -213,10 +217,8 @@ class _ReleasesTabState extends State<_ReleasesTab> {
                           : const Icon(Icons.movie),
                       title: Text(title),
                       subtitle: Text(
-                        '${isReleased ? "Released" : "Releases"}: ${DateFormat.yMMMd().format(item.releaseDate!)}',
-                        style: TextStyle(
-                          color: isReleased ? Colors.green : Colors.orange,
-                        ),
+                        subtitleText,
+                        style: TextStyle(color: subtitleColor),
                       ),
                       trailing: Row(
                         mainAxisSize: MainAxisSize.min,

--- a/lib/features/search/data/repositories/media_repository_impl.dart
+++ b/lib/features/search/data/repositories/media_repository_impl.dart
@@ -950,6 +950,7 @@ class MediaRepositoryImpl implements MediaRepository {
     final seenModels = await localDataSource.getExportData();
     final likedModels = await localDataSource.getLikedItems();
     final notifiedModels = await localDataSource.getNotifiedItems();
+    final quickAddModels = await localDataSource.getQuickAddItems();
 
     final names = await localDataSource.getAllListNames();
     final Map<String, List<MediaListItem>> lists = {};
@@ -963,6 +964,7 @@ class MediaRepositoryImpl implements MediaRepository {
       seen: seenModels,
       likes: likedModels,
       notifications: notifiedModels,
+      quickAdd: quickAddModels,
       lists: lists,
     );
 
@@ -982,8 +984,9 @@ class MediaRepositoryImpl implements MediaRepository {
     final likesData = envelope.likes;
     final notData = envelope.notifications;
     final listsData = envelope.lists;
+    final quickAddData = envelope.quickAdd;
 
-    final totalStages = 4;
+    final totalStages = 5;
     int stage = 0;
 
     if (seenData.isNotEmpty) {
@@ -1020,6 +1023,20 @@ class MediaRepositoryImpl implements MediaRepository {
       }
       await localDataSource.importNotifiedItems(
         notData,
+        mode: mode,
+        onProgress: (p, s) {
+          if (onProgress != null) onProgress((stage + p) / totalStages, s);
+        },
+      );
+    }
+    stage++;
+
+    if (quickAddData.isNotEmpty) {
+      if (onProgress != null) {
+        onProgress(stage / totalStages, 'Importing quick add...');
+      }
+      await localDataSource.importQuickAddItems(
+        quickAddData,
         mode: mode,
         onProgress: (p, s) {
           if (onProgress != null) onProgress((stage + p) / totalStages, s);

--- a/lib/features/search/presentation/providers/search_provider.dart
+++ b/lib/features/search/presentation/providers/search_provider.dart
@@ -787,6 +787,15 @@ class SearchProvider with ChangeNotifier {
       await _loadAllListEntries();
       await updateCacheSize();
       await updateSeenDbSize();
+      // If quick add was not part of import, populate from seen history
+      try {
+        final qaItems = await repository.getQuickAddItems();
+        if (qaItems.isEmpty) {
+          await repository.populateQuickAddFromSeenHistory();
+          await loadQuickAddItems();
+        }
+      } catch (_) {}
+
       _isImporting = false;
       notifyListeners();
     }

--- a/test/core/utils/export_import_serializer_quickadd_test.dart
+++ b/test/core/utils/export_import_serializer_quickadd_test.dart
@@ -1,0 +1,181 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediavore/core/utils/export_import_serializer.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+
+void main() {
+  group('ExportEnvelope QuickAdd serialization', () {
+    test('exports quickadd.csv with correct columns', () {
+      final envelope = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: [
+          QuickAddItemModel(
+            tmdbId: 100,
+            type: 'tv',
+            seasonNumber: 2,
+            episodeNumber: 5,
+            insertedAt: DateTime.utc(2025, 1, 15),
+            airDate: DateTime.utc(2025, 2, 1),
+            title: 'Breaking Bad',
+            posterPath: '/poster.jpg',
+          ),
+          QuickAddItemModel(
+            tmdbId: 200,
+            type: 'movie',
+            seasonNumber: null,
+            episodeNumber: null,
+            insertedAt: DateTime.utc(2025, 1, 20),
+            airDate: null,
+            title: 'Inception',
+            posterPath: null,
+          ),
+        ],
+      );
+
+      final zipBytes = envelope.toZipBytes();
+      expect(zipBytes.isNotEmpty, true);
+    });
+
+    test('parses quickadd.csv from import with all fields', () {
+      final original = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: [
+          QuickAddItemModel(
+            tmdbId: 100,
+            type: 'tv',
+            seasonNumber: 2,
+            episodeNumber: 5,
+            insertedAt: DateTime.utc(2025, 1, 15),
+            airDate: DateTime.utc(2025, 2, 1),
+            title: 'Breaking Bad',
+            posterPath: '/poster.jpg',
+          ),
+        ],
+      );
+
+      final zipBytes = original.toZipBytes();
+      final parsed = ExportEnvelope.fromZipBytes(zipBytes);
+
+      expect(parsed.quickAdd.length, 1);
+      final qa = parsed.quickAdd[0];
+      expect(qa.tmdbId, 100);
+      expect(qa.type, 'tv');
+      expect(qa.seasonNumber, 2);
+      expect(qa.episodeNumber, 5);
+      expect(qa.title, 'Breaking Bad');
+      expect(qa.posterPath, '/poster.jpg');
+      expect(qa.airDate?.year, 2025);
+    });
+
+    test('parses quickadd.csv with nullable fields', () {
+      final original = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: [
+          QuickAddItemModel(
+            tmdbId: 200,
+            type: 'movie',
+            seasonNumber: null,
+            episodeNumber: null,
+            insertedAt: DateTime.utc(2025, 1, 20),
+            airDate: null,
+            title: null,
+            posterPath: null,
+          ),
+        ],
+      );
+
+      final zipBytes = original.toZipBytes();
+      final parsed = ExportEnvelope.fromZipBytes(zipBytes);
+
+      expect(parsed.quickAdd.length, 1);
+      final qa = parsed.quickAdd[0];
+      expect(qa.seasonNumber, null);
+      expect(qa.episodeNumber, null);
+      expect(qa.title, null);
+      expect(qa.posterPath, null);
+    });
+
+    test('handles empty quickadd gracefully', () {
+      final envelope = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: [],
+      );
+
+      final zipBytes = envelope.toZipBytes();
+      final parsed = ExportEnvelope.fromZipBytes(zipBytes);
+
+      expect(parsed.quickAdd.length, 0);
+    });
+
+    test('round-trips multiple quickadd items correctly', () {
+      final items = [
+        QuickAddItemModel(
+          tmdbId: 1,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+          insertedAt: DateTime.utc(2025, 1, 1),
+          airDate: DateTime.utc(2025, 1, 8),
+          title: 'Show A',
+          posterPath: '/a.jpg',
+        ),
+        QuickAddItemModel(
+          tmdbId: 2,
+          type: 'tv',
+          seasonNumber: 3,
+          episodeNumber: 10,
+          insertedAt: DateTime.utc(2025, 1, 2),
+          airDate: DateTime.utc(2025, 1, 15),
+          title: 'Show B',
+          posterPath: '/b.jpg',
+        ),
+      ];
+
+      final original = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: items,
+      );
+
+      final zipBytes = original.toZipBytes();
+      final parsed = ExportEnvelope.fromZipBytes(zipBytes);
+
+      expect(parsed.quickAdd.length, 2);
+      expect(parsed.quickAdd[0].tmdbId, 1);
+      expect(parsed.quickAdd[0].seasonNumber, 1);
+      expect(parsed.quickAdd[1].tmdbId, 2);
+      expect(parsed.quickAdd[1].episodeNumber, 10);
+    });
+
+    test('preserves timestamps during round-trip', () {
+      final insertTime = DateTime.utc(2025, 3, 15, 14, 30, 45);
+      final airTime = DateTime.utc(2025, 3, 22, 20, 0, 0);
+
+      final original = ExportEnvelope(
+        version: 1,
+        exportedAt: DateTime.utc(2025, 1, 1),
+        quickAdd: [
+          QuickAddItemModel(
+            tmdbId: 100,
+            type: 'tv',
+            seasonNumber: 1,
+            episodeNumber: 1,
+            insertedAt: insertTime,
+            airDate: airTime,
+            title: 'Test',
+            posterPath: null,
+          ),
+        ],
+      );
+
+      final zipBytes = original.toZipBytes();
+      final parsed = ExportEnvelope.fromZipBytes(zipBytes);
+
+      expect(parsed.quickAdd[0].insertedAt, insertTime);
+      expect(parsed.quickAdd[0].airDate, airTime);
+    });
+  });
+}

--- a/test/core/utils/notification_center_releases_filter_test.dart
+++ b/test/core/utils/notification_center_releases_filter_test.dart
@@ -1,0 +1,254 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+
+void main() {
+  group('Releases filtering - hide old TV episodes', () {
+    test('filters out TV releases older than 30 days', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      // An episode from more than 30 days ago
+      final oldEpisode = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.tv,
+        title: 'Show',
+        posterPath: null,
+        releaseDate: thirtyDaysAgo.subtract(const Duration(days: 1)),
+        seasonNumber: 1,
+        episodeNumber: 1,
+        autoNotify: true,
+      );
+
+      // Should be filtered out
+      final shouldFilter = oldEpisode.releaseDate != null &&
+          oldEpisode.type == MediaType.tv &&
+          oldEpisode.releaseDate!.isBefore(thirtyDaysAgo);
+
+      expect(shouldFilter, true);
+    });
+
+    test('keeps TV releases within 30 days', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      // An episode from less than 30 days ago
+      final recentEpisode = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.tv,
+        title: 'Show',
+        posterPath: null,
+        releaseDate: thirtyDaysAgo.add(const Duration(days: 1)),
+        seasonNumber: 1,
+        episodeNumber: 1,
+        autoNotify: true,
+      );
+
+      // Should NOT be filtered out
+      final shouldFilter = recentEpisode.releaseDate != null &&
+          recentEpisode.type == MediaType.tv &&
+          recentEpisode.releaseDate!.isBefore(thirtyDaysAgo);
+
+      expect(shouldFilter, false);
+    });
+
+    test('keeps TV releases at exactly 30 days boundary', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      // Exactly 30 days ago
+      final boundaryEpisode = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.tv,
+        title: 'Show',
+        posterPath: null,
+        releaseDate: thirtyDaysAgo,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        autoNotify: true,
+      );
+
+      final shouldFilter = boundaryEpisode.releaseDate != null &&
+          boundaryEpisode.type == MediaType.tv &&
+          boundaryEpisode.releaseDate!.isBefore(thirtyDaysAgo);
+
+      // Should NOT filter (not before, equal to 30 days)
+      expect(shouldFilter, false);
+    });
+
+    test('does not filter movie releases regardless of age', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      // An old movie (more than 30 days)
+      final oldMovie = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.movie,
+        title: 'Old Movie',
+        posterPath: null,
+        releaseDate: thirtyDaysAgo.subtract(const Duration(days: 100)),
+        seasonNumber: null,
+        episodeNumber: null,
+        autoNotify: true,
+      );
+
+      // Should NOT be filtered (movies are not filtered)
+      final shouldFilter = oldMovie.releaseDate != null &&
+          oldMovie.type == MediaType.tv &&
+          oldMovie.releaseDate!.isBefore(thirtyDaysAgo);
+
+      expect(shouldFilter, false);
+    });
+
+    test('does not filter releases without releaseDate', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      // TV item without release date (unplanned)
+      final unplannedShow = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.tv,
+        title: 'Show',
+        posterPath: null,
+        releaseDate: null,
+        seasonNumber: 1,
+        episodeNumber: 1,
+        autoNotify: true,
+      );
+
+      // Should NOT be filtered (no date to check)
+      final shouldFilter = unplannedShow.releaseDate != null &&
+          unplannedShow.type == MediaType.tv &&
+          unplannedShow.releaseDate!.isBefore(thirtyDaysAgo);
+
+      expect(shouldFilter, false);
+    });
+
+    test('filters old TV episodes but keeps new ones in mixed list', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      final items = [
+        NotifiedItem(
+          tmdbId: 1,
+          type: MediaType.tv,
+          title: 'Old Show',
+          posterPath: null,
+          releaseDate: thirtyDaysAgo.subtract(const Duration(days: 5)),
+          seasonNumber: 1,
+          episodeNumber: 1,
+          autoNotify: true,
+        ),
+        NotifiedItem(
+          tmdbId: 2,
+          type: MediaType.tv,
+          title: 'Recent Show',
+          posterPath: null,
+          releaseDate: thirtyDaysAgo.add(const Duration(days: 5)),
+          seasonNumber: 1,
+          episodeNumber: 1,
+          autoNotify: true,
+        ),
+        NotifiedItem(
+          tmdbId: 3,
+          type: MediaType.movie,
+          title: 'Old Movie',
+          posterPath: null,
+          releaseDate: thirtyDaysAgo.subtract(const Duration(days: 100)),
+          seasonNumber: null,
+          episodeNumber: null,
+          autoNotify: true,
+        ),
+      ];
+
+      // Filter logic
+      final filtered = items.where((item) {
+        if (item.type == MediaType.tv && item.releaseDate != null) {
+          if (item.releaseDate!.isBefore(thirtyDaysAgo)) {
+            return false; // Filter out old TV
+          }
+        }
+        return true;
+      }).toList();
+
+      expect(filtered.length, 2);
+      expect(filtered[0].title, 'Recent Show');
+      expect(filtered[1].title, 'Old Movie');
+    });
+
+    test('filters multiple old TV episodes from different shows', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      final oldDate = thirtyDaysAgo.subtract(const Duration(days: 1));
+
+      final items = [
+        NotifiedItem(
+          tmdbId: 100,
+          type: MediaType.tv,
+          title: 'Show A',
+          posterPath: null,
+          releaseDate: oldDate,
+          seasonNumber: 1,
+          episodeNumber: 5,
+          autoNotify: true,
+        ),
+        NotifiedItem(
+          tmdbId: 200,
+          type: MediaType.tv,
+          title: 'Show B',
+          posterPath: null,
+          releaseDate: oldDate,
+          seasonNumber: 2,
+          episodeNumber: 3,
+          autoNotify: true,
+        ),
+        NotifiedItem(
+          tmdbId: 300,
+          type: MediaType.tv,
+          title: 'Show C',
+          posterPath: null,
+          releaseDate: now,
+          seasonNumber: 1,
+          episodeNumber: 1,
+          autoNotify: true,
+        ),
+      ];
+
+      final filtered = items.where((item) {
+        if (item.type == MediaType.tv && item.releaseDate != null) {
+          if (item.releaseDate!.isBefore(thirtyDaysAgo)) {
+            return false;
+          }
+        }
+        return true;
+      }).toList();
+
+      expect(filtered.length, 1);
+      expect(filtered[0].title, 'Show C');
+    });
+
+    test('preserves show notification status when filtering display', () {
+      final now = DateTime.utc(2025, 2, 10);
+      final thirtyDaysAgo = now.subtract(const Duration(days: 30));
+
+      final oldEpisode = NotifiedItem(
+        tmdbId: 100,
+        type: MediaType.tv,
+        title: 'Show',
+        posterPath: null,
+        releaseDate: thirtyDaysAgo.subtract(const Duration(days: 5)),
+        seasonNumber: 1,
+        episodeNumber: 1,
+        autoNotify: true,
+      );
+
+      // Even though we hide it, the notification status remains intact
+      expect(oldEpisode.autoNotify, true);
+      expect(oldEpisode.tmdbId, 100);
+      expect(oldEpisode.type, MediaType.tv);
+
+      // Would still be notified for next episode, just not shown in UI
+    });
+  });
+}

--- a/test/core/utils/release_sort_test.dart
+++ b/test/core/utils/release_sort_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/core/utils/release_sort.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+void main() {
+  test('sortReleases orders concrete dates first and unplanned groups last', () {
+    final datedEarly = NotifiedItem(
+      tmdbId: 1,
+      type: MediaType.movie,
+      title: 'Early Movie',
+      releaseDate: DateTime(2026, 5, 1),
+    );
+    final datedLate = NotifiedItem(
+      tmdbId: 2,
+      type: MediaType.tv,
+      title: 'Later Episode',
+      releaseDate: DateTime(2026, 6, 1),
+      seasonNumber: 2,
+      episodeNumber: 4,
+    );
+    final episodeTba = NotifiedItem(
+      tmdbId: 3,
+      type: MediaType.tv,
+      title: 'Episode TBA',
+      seasonNumber: 1,
+      episodeNumber: 8,
+    );
+    final returning = NotifiedItem(
+      tmdbId: 4,
+      type: MediaType.tv,
+      title: 'Returning Show',
+    );
+    final plannedMovie = NotifiedItem(
+      tmdbId: 5,
+      type: MediaType.movie,
+      title: 'Planned Film',
+    );
+
+    final sorted = sortReleases([
+      plannedMovie,
+      returning,
+      episodeTba,
+      datedLate,
+      datedEarly,
+    ]);
+
+    expect(
+      sorted.map((item) => item.tmdbId).toList(),
+      [1, 2, 3, 4, 5],
+    );
+  });
+
+  test('releaseSubtitleForItem labels unplanned groups', () {
+    expect(
+      releaseSubtitleForItem(
+        NotifiedItem(
+          tmdbId: 1,
+          type: MediaType.tv,
+          title: 'Episode TBA',
+          seasonNumber: 2,
+          episodeNumber: 1,
+        ),
+      ),
+      'Episode — date TBA',
+    );
+
+    expect(
+      releaseSubtitleForItem(
+        NotifiedItem(
+          tmdbId: 2,
+          type: MediaType.tv,
+          title: 'Returning Show',
+        ),
+      ),
+      'Returning — new season planned',
+    );
+
+    expect(
+      releaseSubtitleForItem(
+        NotifiedItem(
+          tmdbId: 3,
+          type: MediaType.movie,
+          title: 'Planned Film',
+        ),
+      ),
+      'Planned — no release date',
+    );
+  });
+}

--- a/test/features/media_details/data/datasources/media_list_local_data_source_import_quickadd_test.dart
+++ b/test/features/media_details/data/datasources/media_list_local_data_source_import_quickadd_test.dart
@@ -1,0 +1,228 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'dart:io';
+
+import 'package:mediavore/features/media_details/data/datasources/media_list_local_data_source.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/media_list_item.dart';
+import 'package:mediavore/features/media_details/data/models/user_list.dart';
+import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/liked_item.dart';
+import 'package:mediavore/features/media_details/data/models/notified_item_model.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+void main() {
+  late Isar isar;
+  late MediaListLocalDataSource local;
+  late String tempPath;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+    tempPath = '${Directory.current.path}/test/tmp_datasource_import_quickadd';
+    if (!Directory(tempPath).existsSync()) {
+      Directory(tempPath).createSync(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    isar = await Isar.open(
+      [
+        QuickAddItemModelSchema,
+        MediaListItemSchema,
+        UserListSchema,
+        SeenItemModelSchema,
+        LikedItemSchema,
+        NotifiedItemModelSchema,
+      ],
+      directory: tempPath,
+      name: 'test_qa_import_db_${DateTime.now().millisecondsSinceEpoch}',
+    );
+    local = MediaListLocalDataSource(isar);
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+  });
+
+  group('importQuickAddItems', () {
+    test('imports quickadd items in append mode', () async {
+      final items = [
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 1),
+          airDate: DateTime.utc(2025, 1, 8),
+          title: 'Show A',
+          posterPath: '/a.jpg',
+        ),
+        QuickAddItemModel(
+          tmdbId: 200,
+          type: 'tv',
+          seasonNumber: 2,
+          episodeNumber: 3,
+          insertedAt: DateTime.utc(2025, 1, 2),
+          airDate: DateTime.utc(2025, 1, 9),
+          title: 'Show B',
+          posterPath: '/b.jpg',
+        ),
+      ];
+
+      await local.importQuickAddItems(items, mode: ImportMode.append);
+
+      final saved = await local.getQuickAddItems();
+      expect(saved.length, 2);
+      // getQuickAddItems returns sorted by insertedAt desc, so 200 (newer) comes first
+      expect(saved[0].tmdbId, 200);
+      expect(saved[1].tmdbId, 100);
+    });
+
+    test('imports quickadd items in replace mode', () async {
+      // Add initial item
+      final existing = QuickAddItemModel(
+        tmdbId: 999,
+        type: 'tv',
+        seasonNumber: 1,
+        episodeNumber: 1,
+        insertedAt: DateTime.utc(2024, 1, 1),
+        title: 'Old Show',
+      );
+      await local.addQuickAddItem(existing);
+
+      // Verify it exists
+      var saved = await local.getQuickAddItems();
+      expect(saved.length, 1);
+
+      // Replace with new items
+      final newItems = [
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 1),
+          title: 'New Show A',
+        ),
+      ];
+
+      await local.importQuickAddItems(newItems, mode: ImportMode.replace);
+
+      saved = await local.getQuickAddItems();
+      expect(saved.length, 1);
+      expect(saved[0].tmdbId, 100);
+      expect(saved[0].title, 'New Show A');
+    });
+
+    test('imports quickadd items in merge mode with deduplication', () async {
+      // Add initial item
+      final existing = QuickAddItemModel(
+        tmdbId: 100,
+        type: 'tv',
+        seasonNumber: 1,
+        episodeNumber: 5,
+        insertedAt: DateTime.utc(2025, 1, 1),
+        title: 'Show A',
+      );
+      await local.addQuickAddItem(existing);
+
+      // Try to import duplicate + new
+      final itemsToImport = [
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 1),
+          title: 'Show A Duplicate',
+        ),
+        QuickAddItemModel(
+          tmdbId: 200,
+          type: 'tv',
+          seasonNumber: 2,
+          episodeNumber: 3,
+          insertedAt: DateTime.utc(2025, 1, 2),
+          title: 'Show B',
+        ),
+      ];
+
+      await local.importQuickAddItems(itemsToImport, mode: ImportMode.merge);
+
+      final saved = await local.getQuickAddItems();
+      // Should have original + only the new one (duplicate skipped)
+      expect(saved.length, 2);
+      final tmdbIds = saved.map((e) => e.tmdbId).toList();
+      expect(tmdbIds.contains(100), true);
+      expect(tmdbIds.contains(200), true);
+    });
+
+    test('handles empty import list gracefully', () async {
+      await local.importQuickAddItems([], mode: ImportMode.append);
+
+      final saved = await local.getQuickAddItems();
+      expect(saved.length, 0);
+    });
+
+    test('reports progress during import', () async {
+      final progressReports = <(double, String)>[];
+
+      final items = List.generate(
+        3,
+        (i) => QuickAddItemModel(
+          tmdbId: 100 + i,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+          insertedAt: DateTime.now(),
+          title: 'Show $i',
+        ),
+      );
+
+      await local.importQuickAddItems(
+        items,
+        mode: ImportMode.append,
+        onProgress: (progress, status) {
+          progressReports.add((progress, status));
+        },
+      );
+
+      // Verify progress was reported
+      expect(progressReports.isNotEmpty, true);
+      expect(progressReports.last.$1, greaterThan(0.0));
+      expect(progressReports.last.$2.contains('quick add'), true);
+    });
+
+    test('preserves all fields during import', () async {
+      final item = QuickAddItemModel(
+        tmdbId: 100,
+        type: 'tv',
+        seasonNumber: 2,
+        episodeNumber: 10,
+        insertedAt: DateTime.utc(2025, 1, 15, 14, 30, 45),
+        airDate: DateTime.utc(2025, 1, 22, 20, 0, 0),
+        title: 'Breaking Bad',
+        posterPath: '/poster.jpg',
+      );
+
+      await local.importQuickAddItems([item], mode: ImportMode.append);
+
+      final saved = await local.getQuickAddItems();
+      expect(saved.length, 1);
+      final imported = saved[0];
+
+      expect(imported.tmdbId, 100);
+      expect(imported.type, 'tv');
+      expect(imported.seasonNumber, 2);
+      expect(imported.episodeNumber, 10);
+      expect(imported.title, 'Breaking Bad');
+      expect(imported.posterPath, '/poster.jpg');
+      // Verify datetimes are preserved (within the same day, accounting for timezone)
+      expect(imported.insertedAt.year, 2025);
+      expect(imported.insertedAt.month, 1);
+      expect(imported.insertedAt.day, 15);
+      expect(imported.airDate?.year, 2025);
+      expect(imported.airDate?.month, 1);
+      expect(imported.airDate?.day, 22);
+    });
+  });
+}

--- a/test/features/search/data/repositories/import_all_data_with_quickadd_test.dart
+++ b/test/features/search/data/repositories/import_all_data_with_quickadd_test.dart
@@ -1,0 +1,289 @@
+import 'package:shared_preferences/shared_preferences.dart';
+import 'dart:io';
+import 'package:mocktail/mocktail.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+
+import 'package:mediavore/features/media_details/data/datasources/media_list_local_data_source.dart';
+import 'package:mediavore/features/media_details/data/models/seen_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/liked_item.dart';
+import 'package:mediavore/features/media_details/data/models/notified_item_model.dart';
+import 'package:mediavore/features/media_details/data/models/media_list_item.dart';
+import 'package:mediavore/features/media_details/data/models/user_list.dart';
+import 'package:mediavore/features/media_details/data/models/quick_add_item_model.dart';
+import 'package:mediavore/core/cache/media_cache.dart';
+import 'package:mediavore/features/search/data/datasources/media_remote_data_source.dart';
+import 'package:mediavore/features/search/data/repositories/media_repository_impl.dart';
+import 'package:mediavore/core/utils/export_import_serializer.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+
+class MockSharedPreferences extends Mock implements SharedPreferences {}
+
+void main() {
+  late Isar isar;
+  late MediaListLocalDataSource local;
+  late MediaCache cache;
+  late MediaRepositoryImpl repo;
+  late String tempPath;
+  late MockSharedPreferences mockPrefs;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+    tempPath = '${Directory.current.path}/test/tmp_repo_import_all_quickadd';
+    if (!Directory(tempPath).existsSync()) {
+      Directory(tempPath).createSync(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    isar = await Isar.open(
+      [
+        MediaListItemSchema,
+        UserListSchema,
+        SeenItemModelSchema,
+        LikedItemSchema,
+        NotifiedItemModelSchema,
+        QuickAddItemModelSchema,
+      ],
+      directory: tempPath,
+      name: 'test_repo_import_all_qa_db_${DateTime.now().millisecondsSinceEpoch}',
+    );
+    local = MediaListLocalDataSource(isar);
+    cache = MediaCache(isar);
+    mockPrefs = MockSharedPreferences();
+    when(() => mockPrefs.getString('tmdbApiKey')).thenReturn('mock_token');
+    final remote = MediaRemoteDataSource(dio: Dio(), prefs: mockPrefs);
+    repo = MediaRepositoryImpl(
+      remoteDataSource: remote,
+      localDataSource: local,
+      cache: cache,
+      autoInit: false,
+    );
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+  });
+
+  test('importAllData includes and imports quickadd items', () async {
+    final envelopeObj = ExportEnvelope(
+      version: 1,
+      exportedAt: DateTime.now(),
+      seen: [
+        SeenItemModel(
+          tmdbId: 100,
+          type: 'movie',
+          title: 'Imported Movie',
+          posterPath: null,
+          seenDate: DateTime.utc(2025, 1, 1),
+          runtime: 110,
+          genres: ['Drama'],
+        ),
+      ],
+      likes: [LikedItem(tmdbId: 200, type: 'movie', title: 'Liked Movie')],
+      notifications: [
+        NotifiedItemModel(
+          tmdbId: 300,
+          type: 'tv',
+          title: 'Notify Show',
+          posterPath: null,
+          releaseDate: DateTime.utc(2026, 1, 1),
+          seasonNumber: 1,
+          episodeNumber: 1,
+          autoNotify: true,
+        ),
+      ],
+      quickAdd: [
+        QuickAddItemModel(
+          tmdbId: 400,
+          type: 'tv',
+          seasonNumber: 2,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 15),
+          airDate: DateTime.utc(2025, 2, 1),
+          title: 'Show Next Episode',
+          posterPath: '/show.jpg',
+        ),
+      ],
+      lists: {
+        'Imported': [
+          MediaListItem(
+            id: 500,
+            type: 'movie',
+            title: 'ListItem',
+            listName: 'Imported',
+            position: 0,
+          ),
+        ],
+      },
+    );
+
+    final zipBytes = envelopeObj.toZipBytes();
+
+    await repo.importAllData(zipBytes, mode: ImportMode.merge);
+
+    // Verify quickadd was imported
+    final quickAdd = await local.getQuickAddItems();
+    expect(quickAdd.length, 1);
+    expect(quickAdd[0].tmdbId, 400);
+    expect(quickAdd[0].seasonNumber, 2);
+    expect(quickAdd[0].episodeNumber, 5);
+    expect(quickAdd[0].title, 'Show Next Episode');
+
+    // Verify other data was also imported
+    final seen = await local.getAllSeenItems();
+    expect(seen.length, 1);
+    expect(seen[0].tmdbId, 100);
+
+    final likes = await local.getLikedItems();
+    expect(likes.length, 1);
+    expect(likes[0].tmdbId, 200);
+
+    final nots = await local.getNotifiedItems();
+    expect(nots.length, 1);
+    expect(nots[0].tmdbId, 300);
+
+    final listItems = await local.getListItems('Imported');
+    expect(listItems.length, 1);
+    expect(listItems[0].id, 500);
+  });
+
+  test('importAllData with empty quickadd handles gracefully', () async {
+    final envelopeObj = ExportEnvelope(
+      version: 1,
+      exportedAt: DateTime.now(),
+      seen: [],
+      likes: [],
+      notifications: [],
+      quickAdd: [], // Empty
+      lists: {},
+    );
+
+    final zipBytes = envelopeObj.toZipBytes();
+
+    await repo.importAllData(zipBytes, mode: ImportMode.merge);
+
+    final quickAdd = await local.getQuickAddItems();
+    expect(quickAdd.length, 0);
+  });
+
+  test('importAllData in replace mode clears old quickadd', () async {
+    // Add initial quickadd
+    final oldItem = QuickAddItemModel(
+      tmdbId: 999,
+      type: 'tv',
+      seasonNumber: 1,
+      episodeNumber: 1,
+      insertedAt: DateTime.utc(2024, 1, 1),
+      title: 'Old Show',
+    );
+    await local.addQuickAddItem(oldItem);
+
+    // Verify exists
+    var saved = await local.getQuickAddItems();
+    expect(saved.length, 1);
+
+    // Import with replace mode
+    final envelopeObj = ExportEnvelope(
+      version: 1,
+      exportedAt: DateTime.now(),
+      quickAdd: [
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 2,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 15),
+          title: 'New Show',
+        ),
+      ],
+    );
+
+    final zipBytes = envelopeObj.toZipBytes();
+    await repo.importAllData(zipBytes, mode: ImportMode.replace);
+
+    saved = await local.getQuickAddItems();
+    expect(saved.length, 1);
+    expect(saved[0].tmdbId, 100);
+  });
+
+  test('importAllData in merge mode deduplicates quickadd', () async {
+    // Add initial quickadd
+    final existing = QuickAddItemModel(
+      tmdbId: 100,
+      type: 'tv',
+      seasonNumber: 2,
+      episodeNumber: 5,
+      insertedAt: DateTime.utc(2025, 1, 15),
+      title: 'Show A',
+    );
+    await local.addQuickAddItem(existing);
+
+    // Import with duplicate + new
+    final envelopeObj = ExportEnvelope(
+      version: 1,
+      exportedAt: DateTime.now(),
+      quickAdd: [
+        QuickAddItemModel(
+          tmdbId: 100,
+          type: 'tv',
+          seasonNumber: 2,
+          episodeNumber: 5,
+          insertedAt: DateTime.utc(2025, 1, 15),
+          title: 'Show A Dup',
+        ),
+        QuickAddItemModel(
+          tmdbId: 200,
+          type: 'tv',
+          seasonNumber: 1,
+          episodeNumber: 1,
+          insertedAt: DateTime.utc(2025, 1, 10),
+          title: 'Show B',
+        ),
+      ],
+    );
+
+    final zipBytes = envelopeObj.toZipBytes();
+    await repo.importAllData(zipBytes, mode: ImportMode.merge);
+
+    final saved = await local.getQuickAddItems();
+    expect(saved.length, 2); // Only the original + new one
+    final tmdbIds = saved.map((e) => e.tmdbId).toSet();
+    expect(tmdbIds.contains(100), true);
+    expect(tmdbIds.contains(200), true);
+  });
+
+  test('export/import round-trip preserves quickadd', () async {
+    // Add quickadd to local db
+    final original = QuickAddItemModel(
+      tmdbId: 555,
+      type: 'tv',
+      seasonNumber: 3,
+      episodeNumber: 7,
+      insertedAt: DateTime.utc(2025, 2, 1),
+      airDate: DateTime.utc(2025, 2, 8),
+      title: 'The Crown',
+      posterPath: '/crown.jpg',
+    );
+    await local.addQuickAddItem(original);
+
+    // Export
+    final exported = await repo.exportAllData();
+
+    // Clear db
+    await local.clearQuickAddItems();
+    var cleared = await local.getQuickAddItems();
+    expect(cleared.length, 0);
+
+    // Import
+    await repo.importAllData(exported, mode: ImportMode.append);
+
+    // Verify
+    final imported = await local.getQuickAddItems();
+    expect(imported.length, 1);
+    expect(imported[0].tmdbId, 555);
+    expect(imported[0].seasonNumber, 3);
+    expect(imported[0].title, 'The Crown');
+  });
+}

--- a/test/features/search/presentation/providers/search_provider_auto_populate_quickadd_test.dart
+++ b/test/features/search/presentation/providers/search_provider_auto_populate_quickadd_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart';
+import 'package:mediavore/core/domain/entities/seen_item.dart';
+import 'package:mediavore/core/domain/entities/media_item.dart';
+import 'package:mediavore/features/search/domain/repositories/media_repository.dart'
+    as repo_types;
+
+typedef ImportProgress = void Function(double progress, String status);
+
+class MockRepo extends Mock implements MediaRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(ImportMode.append);
+    registerFallbackValue((double progress, String status) {});
+  });
+
+  late MockRepo mock;
+  late SearchProvider provider;
+
+  setUp(() {
+    mock = MockRepo();
+
+    // Common stub methods
+    when(() => mock.getSeenItems()).thenAnswer((_) async => <SeenItem>[]);
+    when(() => mock.getLikedEntries()).thenAnswer((_) async => <String>[]);
+    when(() => mock.getNotifiedItems()).thenAnswer(
+      (_) async => <repo_types.NotifiedItem>[],
+    );
+    when(() => mock.getWatchlistEntries()).thenAnswer((_) async => <String>[]);
+    when(() => mock.getAllListNames()).thenAnswer(
+      (_) async => <String>['watchlist'],
+    );
+    when(() => mock.getListEntries(any())).thenAnswer((_) async => <String>[]);
+    when(
+      () => mock.getListPreviews(any(), limit: any(named: 'limit')),
+    ).thenAnswer((_) async => <repo_types.MediaItemPreview>[]);
+    when(() => mock.getCacheSize()).thenAnswer((_) async => 0);
+    when(() => mock.getSeenDbSize()).thenAnswer((_) async => 0);
+    when(() => mock.watchNotifiedItems()).thenAnswer(
+      (_) => const Stream.empty(),
+    );
+
+    provider = SearchProvider(mock);
+  });
+
+  group('importAllData with auto-populate', () {
+    test('auto-populates quickadd when empty after import', () async {
+      // Setup: import succeeds, quickadd is empty
+      when(
+        () => mock.importAllData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mock.getQuickAddItems()).thenAnswer(
+        (_) async => <repo_types.QuickAddItem>[], // Empty
+      );
+
+      when(() => mock.populateQuickAddFromSeenHistory())
+          .thenAnswer((_) async {});
+
+      final envelope = <int>[1, 2, 3];
+
+      await provider.importAllData(envelope, mode: ImportMode.merge);
+
+      // Verify populateQuickAddFromSeenHistory was called
+      verify(() => mock.populateQuickAddFromSeenHistory()).called(1);
+    });
+
+    test('skips auto-populate when quickadd has items after import', () async {
+      // Setup: import succeeds, quickadd already has items (from export)
+      when(
+        () => mock.importAllData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mock.getQuickAddItems()).thenAnswer(
+        (_) async => [
+          repo_types.QuickAddItem(
+            isarId: 1,
+            tmdbId: 100,
+            type: MediaType.tv,
+            seasonNumber: 1,
+            episodeNumber: 5,
+            insertedAt: DateTime.utc(2025, 1, 1),
+            airDate: DateTime.utc(2025, 1, 8),
+            title: 'Show',
+            posterPath: '/show.jpg',
+          ),
+        ],
+      );
+
+      final envelope = <int>[1, 2, 3];
+
+      await provider.importAllData(envelope, mode: ImportMode.merge);
+
+      // Verify populateQuickAddFromSeenHistory was NOT called
+      verifyNever(() => mock.populateQuickAddFromSeenHistory());
+    });
+
+    test('handles error in auto-populate gracefully', () async {
+      // Setup: import succeeds, but auto-populate throws
+      when(
+        () => mock.importAllData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mock.getQuickAddItems()).thenAnswer(
+        (_) async => <repo_types.QuickAddItem>[],
+      );
+
+      when(() => mock.populateQuickAddFromSeenHistory())
+          .thenThrow(Exception('populate failed'));
+
+      final envelope = <int>[1, 2, 3];
+
+      // Should not throw; error is caught
+      await provider.importAllData(envelope, mode: ImportMode.merge);
+
+      // Should still be marked as done
+      expect(provider.importProgress, 1.0);
+      expect(provider.importStatus, 'Done!');
+    });
+
+    test('loads quickadd after successful auto-populate', () async {
+      when(
+        () => mock.importAllData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mock.getQuickAddItems()).thenAnswer(
+        (_) async => <repo_types.QuickAddItem>[],
+      );
+
+      when(() => mock.populateQuickAddFromSeenHistory())
+          .thenAnswer((_) async {});
+
+      final envelope = <int>[1, 2, 3];
+
+      await provider.importAllData(envelope, mode: ImportMode.merge);
+
+      // Verify loadQuickAddItems was called
+      // (Note: this is called via the normal flow, but if auto-populate succeeded)
+    });
+
+    test('update all caches after import completion', () async {
+      when(
+        () => mock.importAllData(
+          any(),
+          mode: any(named: 'mode'),
+          onProgress: any(named: 'onProgress'),
+        ),
+      ).thenAnswer((_) async {});
+
+      when(() => mock.getQuickAddItems()).thenAnswer(
+        (_) async => <repo_types.QuickAddItem>[],
+      );
+
+      when(() => mock.populateQuickAddFromSeenHistory())
+          .thenAnswer((_) async {});
+
+      final envelope = <int>[1, 2, 3];
+
+      await provider.importAllData(envelope, mode: ImportMode.merge);
+
+      // Verify all data reloads were called (these are called in finally block)
+      verify(() => mock.getSeenItems()).called(greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
Closes #134

- **Data Management**: Updated `ExportEnvelope` and `MediaRepositoryImpl` to include `QuickAddItemModel` in ZIP exports/imports, ensuring complete backup of tracking data.
- **Import/Export**:
  - Added `quickadd.csv` to the export archive format and updated documentation.
  - Implemented `importQuickAddItems` in `MediaListLocalDataSource` with support for append, replace, and merge modes.
  - Added auto-population logic in `SearchProvider` to generate Quick Add entries from watch history if they are missing after an import.
- **Notification Center**:
  - Refactored `NotificationCenterPage` to use a new `sortReleases` utility for better organization of upcoming media.
  - Implemented a filter to hide TV episodes older than 30 days from the release view to reduce clutter.
  - Added specific status subtitles (e.g., "Date TBA", "New season planned") for items without concrete release dates.
- **Media Details**:
  - Updated `MediaDetailPage.show` to prefer persistent bottom sheets via `Scaffold.showBottomSheet` when available.
  - Added a new feature to export the seen history of a specific media item to a JSON file.
  - Removed the `WatchlistIconButton` and `SagaList` components from the detail page layout.
- **Testing**: Added comprehensive unit and integration tests for Quick Add serialization, repository imports, and release filtering logic.