### PR TITLE
fix(search, settings): update default display mode and improve image scaling

### DIFF
--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -1603,7 +1603,7 @@ class _MediaListTile extends StatelessWidget {
               const SizedBox(width: 4),
               Flexible(
                 child: Text(
-                  '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : "?"} • $lengthText',
+                  '${item.releaseDate.isNotEmpty == true && item.releaseDate.length >= 4 ? item.releaseDate.substring(0, 4) : "?"} • $lengthText',
                   overflow: TextOverflow.ellipsis,
                   maxLines: 1,
                 ),
@@ -1728,7 +1728,7 @@ class _MediaGridItem extends StatelessWidget {
                         ),
                         const SizedBox(height: 2),
                         Text(
-                          '${item.releaseDate?.isNotEmpty == true && item.releaseDate!.length >= 4 ? item.releaseDate!.substring(0, 4) : ""} • $lengthText',
+                          '${item.releaseDate.isNotEmpty == true && item.releaseDate.length >= 4 ? item.releaseDate.substring(0, 4) : ""} • $lengthText',
                           style: const TextStyle(
                             color: Colors.white70,
                             fontSize: 9,
@@ -1925,25 +1925,29 @@ class _PosterWithBadge extends StatelessWidget {
         ClipRRect(
           borderRadius: BorderRadius.circular(8),
           child: item.posterPath != null
-              ? CachedNetworkImage(
-                  imageUrl: 'https://image.tmdb.org/t/p/w342${item.posterPath}',
-                  width: width,
-                  height: height,
-                  fit: BoxFit.cover,
-                  placeholder: (context, url) => const Center(
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-                  errorWidget: (context, url, error) =>
-                      Icon(isTv ? Icons.tv : Icons.movie, size: width),
-                )
+                  ? CachedNetworkImage(
+                      imageUrl: 'https://image.tmdb.org/t/p/w342${item.posterPath}',
+                      width: width,
+                      height: height,
+                      fit: BoxFit.cover,
+                      placeholder: (context, url) => const Center(
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                      errorWidget: (context, url, error) => Icon(
+                        isTv ? Icons.tv : Icons.movie,
+                        size: (width?.isFinite == true) ? width : 48,
+                      ),
+                    )
               : Container(
                   width: width,
                   height: height,
                   color: colors.placeholder,
-                  child: Icon(
-                    isTv ? Icons.tv : Icons.movie,
-                    size: width != null ? width! / 2 : 24,
-                  ),
+                                    child: Icon(
+                                      isTv ? Icons.tv : Icons.movie,
+                                        size: (width?.isFinite == true)
+                                          ? (width! / 2)
+                                          : 24,
+                                    ),
                 ),
         ),
         if (isSeen && showBadge)

--- a/lib/features/settings/presentation/providers/settings_provider.dart
+++ b/lib/features/settings/presentation/providers/settings_provider.dart
@@ -11,7 +11,7 @@ class SettingsProvider with ChangeNotifier {
     _loadSettings();
   }
 
-  DisplayMode _displayMode = DisplayMode.list;
+  DisplayMode _displayMode = DisplayMode.grid;
   double _gridSize = 3.0;
   bool _hideNonReleased = false;
 
@@ -33,11 +33,15 @@ class SettingsProvider with ChangeNotifier {
   AppPalette get darkPalette => darkThemes[_darkAppThemeIndex].palette;
 
   void _loadSettings() {
-    int displayModeIndex = _prefs.getInt('displayMode') ?? 0;
-    if (displayModeIndex < 0 || displayModeIndex >= DisplayMode.values.length) {
-      displayModeIndex = 0;
+    // Only override the in-memory default if a persisted value exists.
+    final int? storedDisplayModeIndex = _prefs.getInt('displayMode');
+    if (storedDisplayModeIndex != null) {
+      var displayModeIndex = storedDisplayModeIndex;
+      if (displayModeIndex < 0 || displayModeIndex >= DisplayMode.values.length) {
+        displayModeIndex = 0;
+      }
+      _displayMode = DisplayMode.values[displayModeIndex];
     }
-    _displayMode = DisplayMode.values[displayModeIndex];
 
     _gridSize = _prefs.getDouble('gridSize') ?? 3.0;
     _hideNonReleased = _prefs.getBool('hideNonReleased') ?? false;

--- a/test/features/search/presentation/pages/discovery_page_test.dart
+++ b/test/features/search/presentation/pages/discovery_page_test.dart
@@ -192,7 +192,8 @@ void main() {
     await tester.tap(find.byIcon(Icons.grid_on));
     await tester.pumpAndSettle();
 
-    expect(find.text('Adjust Grid Size'), findsOneWidget);
+    // The UI shows 'Grid Size' inside the display options sheet
+    expect(find.text('Grid Size'), findsOneWidget);
 
     final slider = find.byType(Slider);
     await tester.drag(slider, const Offset(100, 0));

--- a/test/features/settings/presentation/providers/settings_provider_test.dart
+++ b/test/features/settings/presentation/providers/settings_provider_test.dart
@@ -26,7 +26,7 @@ void main() {
     test(
       'should initialize with default values when SharedPreferences is empty',
       () {
-        expect(provider.displayMode, DisplayMode.list);
+        expect(provider.displayMode, DisplayMode.grid);
         expect(provider.gridSize, 3.0);
         expect(provider.themeMode, ThemeMode.system);
         expect(provider.lightAppThemeIndex, 0);


### PR DESCRIPTION
Closes #136

- Change default `DisplayMode` from `list` to `grid` in `SettingsProvider`.
- Update `SettingsProvider` logic to only override the in-memory default when a persisted value exists.
- Add safety checks for `width` in `SavedMediaPage` to handle non-finite values when rendering poster icons.
- Update `discovery_page_test.dart` to reflect UI text changes for grid size adjustment.
- Update `settings_provider_test.dart` to align with the new default grid display mode.