### PR TITLE
fix(media_details): restored watchlist button to media detail page

### DIFF
--- a/lib/features/media_details/presentation/pages/media_detail_page.dart
+++ b/lib/features/media_details/presentation/pages/media_detail_page.dart
@@ -13,6 +13,7 @@ import 'package:mediavore/features/media_details/presentation/widgets/media_list
 import 'package:mediavore/features/media_details/presentation/widgets/seen_manager.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/like_button.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/notify_button.dart';
+import 'package:mediavore/features/media_details/presentation/widgets/watchlist_icon_button.dart';
 import 'package:mediavore/features/media_details/presentation/widgets/watch_next_button.dart';
 import 'package:mediavore/features/search/presentation/providers/search_provider.dart';
 import 'package:path_provider/path_provider.dart';
@@ -340,6 +341,7 @@ class _MediaDetailPageState extends State<MediaDetailPage> {
             actions: [
               LikeButton(item: itemToDisplay),
               NotifyButton(item: itemToDisplay),
+              WatchlistIconButton(item: itemToDisplay),
               IconButton(
                 icon: const Icon(Icons.file_upload_outlined),
                 onPressed: _exportHistory,

--- a/lib/features/search/presentation/pages/saved_media_page.dart
+++ b/lib/features/search/presentation/pages/saved_media_page.dart
@@ -1925,29 +1925,27 @@ class _PosterWithBadge extends StatelessWidget {
         ClipRRect(
           borderRadius: BorderRadius.circular(8),
           child: item.posterPath != null
-                  ? CachedNetworkImage(
-                      imageUrl: 'https://image.tmdb.org/t/p/w342${item.posterPath}',
-                      width: width,
-                      height: height,
-                      fit: BoxFit.cover,
-                      placeholder: (context, url) => const Center(
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                      errorWidget: (context, url, error) => Icon(
-                        isTv ? Icons.tv : Icons.movie,
-                        size: (width?.isFinite == true) ? width : 48,
-                      ),
-                    )
+              ? CachedNetworkImage(
+                  imageUrl: 'https://image.tmdb.org/t/p/w342${item.posterPath}',
+                  width: width,
+                  height: height,
+                  fit: BoxFit.cover,
+                  placeholder: (context, url) => const Center(
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  errorWidget: (context, url, error) => Icon(
+                    isTv ? Icons.tv : Icons.movie,
+                    size: (width?.isFinite == true) ? width : 48,
+                  ),
+                )
               : Container(
                   width: width,
                   height: height,
                   color: colors.placeholder,
-                                    child: Icon(
-                                      isTv ? Icons.tv : Icons.movie,
-                                        size: (width?.isFinite == true)
-                                          ? (width! / 2)
-                                          : 24,
-                                    ),
+                  child: Icon(
+                    isTv ? Icons.tv : Icons.movie,
+                    size: (width?.isFinite == true) ? (width! / 2) : 24,
+                  ),
                 ),
         ),
         if (isSeen && showBadge)


### PR DESCRIPTION
Closes #139 

- Restored `WatchlistIconButton` to the actions list in `MediaDetailPage` to allow users to toggle items on their watchlist.