### PR TITLE
feat(media_details): display media runtime in seen history page

### DIFF
--- a/lib/features/media_details/presentation/pages/seen_history_page.dart
+++ b/lib/features/media_details/presentation/pages/seen_history_page.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:mediavore/core/utils/formatters.dart';
 import 'package:mediavore/core/domain/entities/media_item.dart';
 import 'package:mediavore/core/domain/entities/seen_item.dart';
 import 'package:mediavore/features/media_details/presentation/pages/media_detail_page.dart';
@@ -366,6 +367,11 @@ class SeenHistoryPageState extends State<SeenHistoryPage> {
                   subtitle +=
                       (subtitle.isNotEmpty ? ' • ' : '') +
                       DateFormat.yMd().format(seenItem.seenDate);
+                }
+
+                final runtimeText = Formatters.formatRuntime(seenItem.runtime);
+                if (runtimeText.isNotEmpty) {
+                  subtitle += (subtitle.isNotEmpty ? ' • ' : '') + runtimeText;
                 }
 
                 return Dismissible(

--- a/test/features/media_details/presentation/pages/seen_history_page_test.dart
+++ b/test/features/media_details/presentation/pages/seen_history_page_test.dart
@@ -107,6 +107,7 @@ void main() {
         type: MediaType.movie,
         title: 'Movie A',
         seenDate: seenDate,
+        runtime: 130,
       ),
       SeenItem(
         id: 2,
@@ -138,6 +139,7 @@ void main() {
     expect(find.byIcon(Icons.favorite), findsOneWidget);
     // Check group header
     expect(find.textContaining('October 1, 2023'), findsOneWidget);
+    expect(find.textContaining('2h 10m'), findsOneWidget);
   });
 
   testWidgets('swiping to delete shows confirmation and calls delete', (


### PR DESCRIPTION
Closes #141

- Updated `SeenHistoryPage` to include the formatted runtime (e.g., "2h 10m") in the list item subtitle.
- Integrated `Formatters.formatRuntime` for consistent duration display.
- Updated `SeenHistoryPage` widget tests to verify that runtime information is correctly rendered.